### PR TITLE
Fix generation handling of dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsIO"
 uuid = "a5388770-19df-4151-b103-3d71de896ddf"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsIO"
 uuid = "a5388770-19df-4151-b103-3d71de896ddf"
-version = "1.0.1"
+version = "1.0.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/gen/Manifest.toml
+++ b/gen/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.2"
 manifest_format = "2.0"
-project_hash = "46342e1b48a16f578d983378fc2b627a4124a3d5"
+project_hash = "bd802c34455e572f67caa68a2beb6ffc7761162e"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -81,6 +81,18 @@ deps = ["Artifacts", "Preferences"]
 git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.5.0"
+
+[[deps.LibAwsCal]]
+deps = ["CEnum", "LibAwsCommon", "aws_c_cal_jll"]
+git-tree-sha1 = "cb38f20d8e187a33770840e2a2eaef8c13ee425d"
+uuid = "ef519ef6-af43-41a0-8ac4-eb81328190af"
+version = "1.0.0"
+
+[[deps.LibAwsCommon]]
+deps = ["CEnum", "aws_c_common_jll"]
+git-tree-sha1 = "d8705f05415a487369d5bbfb2ca149c72ffb5609"
+uuid = "c6e421ba-b5f8-4792-a1c4-42948de3ed9d"
+version = "1.0.0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
 JLLPrefixes = "afc68a34-7891-4c5a-9da1-1c62935e7b0d"
+LibAwsCal = "ef519ef6-af43-41a0-8ac4-eb81328190af"
+LibAwsCommon = "c6e421ba-b5f8-4792-a1c4-42948de3ed9d"
 aws_c_cal_jll = "70f11efc-bab2-57f1-b0f3-22aad4e67c4b"
 aws_c_common_jll = "73048d1d-b8c4-5092-a58d-866c5e8d1e50"
 aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"

--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -2,6 +2,8 @@ using Clang.Generators
 using Clang.JLLEnvs
 using JLLPrefixes
 import aws_c_common_jll, aws_c_io_jll, aws_c_cal_jll
+using LibAwsCommon
+using LibAwsCal
 
 cd(@__DIR__)
 
@@ -27,6 +29,21 @@ function should_skip_target(target)
     return target == "i686-w64-mingw32"
 end
 
+const deps_jlls = [aws_c_common_jll, aws_c_cal_jll]
+const deps = [LibAwsCommon, LibAwsCal]
+const deps_names = sort(collect(Iterators.flatten(names.(deps))))
+
+# clang can emit code for forward declarations of structs defined in our dependencies. we need to skip those, otherwise
+# we'll have duplicate struct definitions.
+function skip_nodes_in_dependencies!(dag::ExprDAG)
+    replace!(get_nodes(dag)) do node
+        if insorted(node.id, deps_names)
+            return ExprNode(node.id, Generators.Skip(), node.cursor, Expr[], node.adj)
+        end
+        return node
+    end
+end
+
 # download toolchains in parallel
 Threads.@threads for target in JLLEnvs.JLL_ENV_TRIPLES
     if should_skip_target(target)
@@ -44,11 +61,10 @@ for target in JLLEnvs.JLL_ENV_TRIPLES
     options["general"]["callback_documentation"] = get_docs
 
     args = get_default_args(target)
-    inc = JLLEnvs.get_pkg_include_dir(aws_c_common_jll, target)
-    push!(args, "-isystem$inc")
-
-    inc = JLLEnvs.get_pkg_include_dir(aws_c_cal_jll, target)
-    push!(args, "-isystem$inc")
+    for dep in deps_jlls
+        inc = JLLEnvs.get_pkg_include_dir(dep, target)
+        push!(args, "-isystem$inc")
+    end
 
     header_dirs = []
     inc = JLLEnvs.get_pkg_include_dir(aws_c_io_jll, target)
@@ -68,5 +84,7 @@ for target in JLLEnvs.JLL_ENV_TRIPLES
     unique!(headers)
 
     ctx = create_context(headers, args, options)
-    build!(ctx)
+    build!(ctx, BUILDSTAGE_NO_PRINTING)
+    skip_nodes_in_dependencies!(ctx.dag)
+    build!(ctx, BUILDSTAGE_PRINTING_ONLY)
 end

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -6718,21 +6718,6 @@ function aws_input_stream_new_tester(alloc, options)
 end
 
 """
-    __pthread_mutex_s
-
-Documentation not found.
-"""
-struct __pthread_mutex_s
-    __lock::Cint
-    __count::Cuint
-    __owner::Cint
-    __nusers::Cuint
-    __kind::Cint
-    __spins::Cint
-    __list::__pthread_list_t
-end
-
-"""
     __JL_Ctag_710
 
 Documentation not found.

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -6718,37 +6718,6 @@ function aws_input_stream_new_tester(alloc, options)
 end
 
 """
-    __pthread_mutex_s
-
-Documentation not found.
-"""
-struct __pthread_mutex_s
-    data::NTuple{24, UInt8}
-end
-
-function Base.getproperty(x::Ptr{__pthread_mutex_s}, f::Symbol)
-    f === :__lock && return Ptr{Cint}(x + 0)
-    f === :__count && return Ptr{Cuint}(x + 4)
-    f === :__owner && return Ptr{Cint}(x + 8)
-    f === :__kind && return Ptr{Cint}(x + 12)
-    f === :__nusers && return Ptr{Cuint}(x + 16)
-    f === :__spins && return Ptr{Cint}(x + 20)
-    f === :__list && return Ptr{__pthread_slist_t}(x + 20)
-    return getfield(x, f)
-end
-
-function Base.getproperty(x::__pthread_mutex_s, f::Symbol)
-    r = Ref{__pthread_mutex_s}(x)
-    ptr = Base.unsafe_convert(Ptr{__pthread_mutex_s}, r)
-    fptr = getproperty(ptr, f)
-    GC.@preserve r unsafe_load(fptr)
-end
-
-function Base.setproperty!(x::Ptr{__pthread_mutex_s}, f::Symbol, v)
-    unsafe_store!(getproperty(x, f), v)
-end
-
-"""
     __JL_Ctag_709
 
 Documentation not found.

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -6757,37 +6757,6 @@ end
 
 
 """
-    __pthread_mutex_s
-
-Documentation not found.
-"""
-struct __pthread_mutex_s
-    data::NTuple{24, UInt8}
-end
-
-function Base.getproperty(x::Ptr{__pthread_mutex_s}, f::Symbol)
-    f === :__lock && return Ptr{Cint}(x + 0)
-    f === :__count && return Ptr{Cuint}(x + 4)
-    f === :__owner && return Ptr{Cint}(x + 8)
-    f === :__kind && return Ptr{Cint}(x + 12)
-    f === :__nusers && return Ptr{Cuint}(x + 16)
-    f === :__spins && return Ptr{Cint}(x + 20)
-    f === :__list && return Ptr{__pthread_slist_t}(x + 20)
-    return getfield(x, f)
-end
-
-function Base.getproperty(x::__pthread_mutex_s, f::Symbol)
-    r = Ref{__pthread_mutex_s}(x)
-    ptr = Base.unsafe_convert(Ptr{__pthread_mutex_s}, r)
-    fptr = getproperty(ptr, f)
-    GC.@preserve r unsafe_load(fptr)
-end
-
-function Base.setproperty!(x::Ptr{__pthread_mutex_s}, f::Symbol, v)
-    unsafe_store!(getproperty(x, f), v)
-end
-
-"""
 Documentation not found.
 """
 const AWS_C_IO_PACKAGE_ID = 1

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -6757,21 +6757,6 @@ end
 
 
 """
-    __pthread_mutex_s
-
-Documentation not found.
-"""
-struct __pthread_mutex_s
-    __lock::Cint
-    __count::Cuint
-    __owner::Cint
-    __nusers::Cuint
-    __kind::Cint
-    __spins::Cint
-    __list::__pthread_list_t
-end
-
-"""
 Documentation not found.
 """
 const AWS_C_IO_PACKAGE_ID = 1

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -6757,21 +6757,6 @@ end
 
 
 """
-    __pthread_mutex_s
-
-Documentation not found.
-"""
-struct __pthread_mutex_s
-    __lock::Cint
-    __count::Cuint
-    __owner::Cint
-    __nusers::Cuint
-    __kind::Cint
-    __spins::Cint
-    __list::__pthread_list_t
-end
-
-"""
 Documentation not found.
 """
 const AWS_C_IO_PACKAGE_ID = 1


### PR DESCRIPTION
We were generating some definitions handled by our dependencies not caught by the system headers trick.
This is something we'll need to do for all packages.

~~Also this is technically a breaking change, but these symbols were already exported by LibAwsCommon, and nobody should have been using them anyway, so I'm in favor of a patch release instead.~~
We haven't registered this yet, nevermind
