### PR TITLE
[DO NOT MERGE] Lib changes needed

### DIFF
--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1207,7 +1207,7 @@ struct aws_client_bootstrap *aws_client_bootstrap_new( struct aws_allocator *all
 ```
 """
 function aws_client_bootstrap_new(allocator, options)
-    ccall((:aws_client_bootstrap_new, libaws_c_io), Ptr{aws_client_bootstrap}, (Ptr{aws_allocator}, Ptr{aws_client_bootstrap_options}), allocator, options)
+    ccall((:aws_client_bootstrap_new, libaws_c_io), Ptr{aws_client_bootstrap}, (Ptr{aws_allocator}, Ref{aws_client_bootstrap_options}), allocator, options)
 end
 
 """
@@ -2897,7 +2897,7 @@ struct aws_host_resolver *aws_host_resolver_new_default( struct aws_allocator *a
 ```
 """
 function aws_host_resolver_new_default(allocator, options)
-    ccall((:aws_host_resolver_new_default, libaws_c_io), Ptr{aws_host_resolver}, (Ptr{aws_allocator}, Ptr{aws_host_resolver_default_options}), allocator, options)
+    ccall((:aws_host_resolver_new_default, libaws_c_io), Ptr{aws_host_resolver}, (Ptr{aws_allocator}, Ref{aws_host_resolver_default_options}), allocator, options)
 end
 
 """


### PR DESCRIPTION
@Octogonapus, do you happen to know what we need to tweak in the generated bindings to get these examples to work? To spell out the problem as clearly as possible:
  * I'm creating a struct like `resolver_options = aws_host_resolver_default_options(8, el_group, C_NULL, C_NULL)`
  * Then trying to call `host_resolver = aws_host_resolver_new_default(allocator, resolver_options)`

But getting an unsafe_convert error because an _instance_ of `aws_host_resolver_default_options` can't be convert to `Ptr{aws_host_resolver_default_options}`. The correct ccall pattern here is to specify the struct pointer type as `Ref{aws_host_resolver_default_options}` and this fixes my usage.

If you happen to know what we need to tweak in the bindings generation, I can make the changes, just wanted to check since you know the generation process much better than I do.