### PR TITLE
Update aws_c_io_jll to version 0.17.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsIO"
 uuid = "a5388770-19df-4151-b103-3d71de896ddf"
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -13,7 +13,7 @@ Aqua = "0.7"
 CEnum = "0.5"
 LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
-aws_c_io_jll = "=0.17.0"
+aws_c_io_jll = "=0.17.1"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -10,4 +10,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_io_jll = "=0.17.0"
+aws_c_io_jll = "=0.17.1"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1302,28 +1302,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/3be393b1691380a19a4cc5a0e2812e63157856bb/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/d7fa80b3f98973c08b99bcc35f868bd2849a4a51/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/3be393b1691380a19a4cc5a0e2812e63157856bb/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/d7fa80b3f98973c08b99bcc35f868bd2849a4a51/include/aws/io/io.h:18:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3be393b1691380a19a4cc5a0e2812e63157856bb/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d7fa80b3f98973c08b99bcc35f868bd2849a4a51/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3be393b1691380a19a4cc5a0e2812e63157856bb/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3be393b1691380a19a4cc5a0e2812e63157856bb/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3be393b1691380a19a4cc5a0e2812e63157856bb/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d7fa80b3f98973c08b99bcc35f868bd2849a4a51/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d7fa80b3f98973c08b99bcc35f868bd2849a4a51/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d7fa80b3f98973c08b99bcc35f868bd2849a4a51/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3be393b1691380a19a4cc5a0e2812e63157856bb/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d7fa80b3f98973c08b99bcc35f868bd2849a4a51/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1337,7 +1337,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3be393b1691380a19a4cc5a0e2812e63157856bb/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d7fa80b3f98973c08b99bcc35f868bd2849a4a51/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     return getfield(x, f)
 end
@@ -5550,11 +5550,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/3be393b1691380a19a4cc5a0e2812e63157856bb/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/d7fa80b3f98973c08b99bcc35f868bd2849a4a51/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/3be393b1691380a19a4cc5a0e2812e63157856bb/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/d7fa80b3f98973c08b99bcc35f868bd2849a4a51/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5577,7 +5577,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3be393b1691380a19a4cc5a0e2812e63157856bb/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/d7fa80b3f98973c08b99bcc35f868bd2849a4a51/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 336)
     return getfield(x, f)
 end

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1302,28 +1302,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/f85624cf96b0107b14236d77e001340a19913e3d/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/bdf6d6c8469a00338b1399503f9a06fd8fb8c54c/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/f85624cf96b0107b14236d77e001340a19913e3d/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/bdf6d6c8469a00338b1399503f9a06fd8fb8c54c/include/aws/io/io.h:18:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f85624cf96b0107b14236d77e001340a19913e3d/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bdf6d6c8469a00338b1399503f9a06fd8fb8c54c/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f85624cf96b0107b14236d77e001340a19913e3d/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f85624cf96b0107b14236d77e001340a19913e3d/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f85624cf96b0107b14236d77e001340a19913e3d/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bdf6d6c8469a00338b1399503f9a06fd8fb8c54c/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bdf6d6c8469a00338b1399503f9a06fd8fb8c54c/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bdf6d6c8469a00338b1399503f9a06fd8fb8c54c/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f85624cf96b0107b14236d77e001340a19913e3d/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bdf6d6c8469a00338b1399503f9a06fd8fb8c54c/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1337,7 +1337,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f85624cf96b0107b14236d77e001340a19913e3d/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bdf6d6c8469a00338b1399503f9a06fd8fb8c54c/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     return getfield(x, f)
 end
@@ -5547,11 +5547,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/f85624cf96b0107b14236d77e001340a19913e3d/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/bdf6d6c8469a00338b1399503f9a06fd8fb8c54c/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/f85624cf96b0107b14236d77e001340a19913e3d/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/bdf6d6c8469a00338b1399503f9a06fd8fb8c54c/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5574,7 +5574,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/f85624cf96b0107b14236d77e001340a19913e3d/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/bdf6d6c8469a00338b1399503f9a06fd8fb8c54c/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 320)
     return getfield(x, f)
 end

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1356,28 +1356,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/8593a74ec206d962721f19d994ad158a3984502f/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/a4b62236806d348ea3bd2ba0d17349a05513f217/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/8593a74ec206d962721f19d994ad158a3984502f/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a4b62236806d348ea3bd2ba0d17349a05513f217/include/aws/io/io.h:18:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8593a74ec206d962721f19d994ad158a3984502f/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a4b62236806d348ea3bd2ba0d17349a05513f217/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8593a74ec206d962721f19d994ad158a3984502f/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8593a74ec206d962721f19d994ad158a3984502f/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8593a74ec206d962721f19d994ad158a3984502f/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a4b62236806d348ea3bd2ba0d17349a05513f217/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a4b62236806d348ea3bd2ba0d17349a05513f217/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a4b62236806d348ea3bd2ba0d17349a05513f217/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8593a74ec206d962721f19d994ad158a3984502f/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a4b62236806d348ea3bd2ba0d17349a05513f217/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1391,7 +1391,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8593a74ec206d962721f19d994ad158a3984502f/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a4b62236806d348ea3bd2ba0d17349a05513f217/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     return getfield(x, f)
 end
@@ -5601,11 +5601,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/8593a74ec206d962721f19d994ad158a3984502f/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/a4b62236806d348ea3bd2ba0d17349a05513f217/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/8593a74ec206d962721f19d994ad158a3984502f/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/a4b62236806d348ea3bd2ba0d17349a05513f217/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5628,7 +5628,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/8593a74ec206d962721f19d994ad158a3984502f/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a4b62236806d348ea3bd2ba0d17349a05513f217/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1302,28 +1302,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/89543fec56688c511fb5147786bbe18c6811842c/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/fc4135d1517e5be728da219906dcc32376d1ac60/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/89543fec56688c511fb5147786bbe18c6811842c/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/fc4135d1517e5be728da219906dcc32376d1ac60/include/aws/io/io.h:18:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/89543fec56688c511fb5147786bbe18c6811842c/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fc4135d1517e5be728da219906dcc32376d1ac60/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/89543fec56688c511fb5147786bbe18c6811842c/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/89543fec56688c511fb5147786bbe18c6811842c/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/89543fec56688c511fb5147786bbe18c6811842c/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/fc4135d1517e5be728da219906dcc32376d1ac60/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/fc4135d1517e5be728da219906dcc32376d1ac60/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fc4135d1517e5be728da219906dcc32376d1ac60/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/89543fec56688c511fb5147786bbe18c6811842c/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fc4135d1517e5be728da219906dcc32376d1ac60/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1337,7 +1337,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/89543fec56688c511fb5147786bbe18c6811842c/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fc4135d1517e5be728da219906dcc32376d1ac60/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     return getfield(x, f)
 end
@@ -5547,11 +5547,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/89543fec56688c511fb5147786bbe18c6811842c/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/fc4135d1517e5be728da219906dcc32376d1ac60/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/89543fec56688c511fb5147786bbe18c6811842c/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/fc4135d1517e5be728da219906dcc32376d1ac60/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5574,7 +5574,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 32)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 88)
     f === :thread && return Ptr{aws_thread}(x + 92)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/89543fec56688c511fb5147786bbe18c6811842c/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/fc4135d1517e5be728da219906dcc32376d1ac60/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 208)
     return getfield(x, f)
 end

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1356,28 +1356,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/f1064f67cbd37dd0f1dc3f600c3d33aa85514617/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/a2393fcbe337e75bfd16e28b26662c8e93e4e9d3/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/f1064f67cbd37dd0f1dc3f600c3d33aa85514617/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a2393fcbe337e75bfd16e28b26662c8e93e4e9d3/include/aws/io/io.h:18:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f1064f67cbd37dd0f1dc3f600c3d33aa85514617/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2393fcbe337e75bfd16e28b26662c8e93e4e9d3/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f1064f67cbd37dd0f1dc3f600c3d33aa85514617/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f1064f67cbd37dd0f1dc3f600c3d33aa85514617/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f1064f67cbd37dd0f1dc3f600c3d33aa85514617/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a2393fcbe337e75bfd16e28b26662c8e93e4e9d3/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a2393fcbe337e75bfd16e28b26662c8e93e4e9d3/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2393fcbe337e75bfd16e28b26662c8e93e4e9d3/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f1064f67cbd37dd0f1dc3f600c3d33aa85514617/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2393fcbe337e75bfd16e28b26662c8e93e4e9d3/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1391,7 +1391,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f1064f67cbd37dd0f1dc3f600c3d33aa85514617/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a2393fcbe337e75bfd16e28b26662c8e93e4e9d3/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     return getfield(x, f)
 end
@@ -5601,11 +5601,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/f1064f67cbd37dd0f1dc3f600c3d33aa85514617/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/a2393fcbe337e75bfd16e28b26662c8e93e4e9d3/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/f1064f67cbd37dd0f1dc3f600c3d33aa85514617/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/a2393fcbe337e75bfd16e28b26662c8e93e4e9d3/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5628,7 +5628,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 32)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 88)
     f === :thread && return Ptr{aws_thread}(x + 92)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/f1064f67cbd37dd0f1dc3f600c3d33aa85514617/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a2393fcbe337e75bfd16e28b26662c8e93e4e9d3/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 196)
     return getfield(x, f)
 end

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1302,28 +1302,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/fde8d4ff2f39c8e43d2b9177910d4c6fb3b3ca2a/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/895698b32f55841662726230d50fedf75d1da373/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/fde8d4ff2f39c8e43d2b9177910d4c6fb3b3ca2a/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/895698b32f55841662726230d50fedf75d1da373/include/aws/io/io.h:18:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fde8d4ff2f39c8e43d2b9177910d4c6fb3b3ca2a/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/895698b32f55841662726230d50fedf75d1da373/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/fde8d4ff2f39c8e43d2b9177910d4c6fb3b3ca2a/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/fde8d4ff2f39c8e43d2b9177910d4c6fb3b3ca2a/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fde8d4ff2f39c8e43d2b9177910d4c6fb3b3ca2a/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/895698b32f55841662726230d50fedf75d1da373/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/895698b32f55841662726230d50fedf75d1da373/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/895698b32f55841662726230d50fedf75d1da373/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fde8d4ff2f39c8e43d2b9177910d4c6fb3b3ca2a/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/895698b32f55841662726230d50fedf75d1da373/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1337,7 +1337,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fde8d4ff2f39c8e43d2b9177910d4c6fb3b3ca2a/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/895698b32f55841662726230d50fedf75d1da373/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     return getfield(x, f)
 end
@@ -5547,11 +5547,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/fde8d4ff2f39c8e43d2b9177910d4c6fb3b3ca2a/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/895698b32f55841662726230d50fedf75d1da373/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/fde8d4ff2f39c8e43d2b9177910d4c6fb3b3ca2a/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/895698b32f55841662726230d50fedf75d1da373/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5574,7 +5574,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 28)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 80)
     f === :thread && return Ptr{aws_thread}(x + 84)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/fde8d4ff2f39c8e43d2b9177910d4c6fb3b3ca2a/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/895698b32f55841662726230d50fedf75d1da373/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 188)
     return getfield(x, f)
 end

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1356,28 +1356,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/344d0ff1766a8581939695c451316710602ef0b8/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/2a9d795f7999a764aa7e432324d1e54aa7da7123/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/344d0ff1766a8581939695c451316710602ef0b8/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/2a9d795f7999a764aa7e432324d1e54aa7da7123/include/aws/io/io.h:18:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/344d0ff1766a8581939695c451316710602ef0b8/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2a9d795f7999a764aa7e432324d1e54aa7da7123/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/344d0ff1766a8581939695c451316710602ef0b8/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/344d0ff1766a8581939695c451316710602ef0b8/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/344d0ff1766a8581939695c451316710602ef0b8/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2a9d795f7999a764aa7e432324d1e54aa7da7123/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2a9d795f7999a764aa7e432324d1e54aa7da7123/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2a9d795f7999a764aa7e432324d1e54aa7da7123/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/344d0ff1766a8581939695c451316710602ef0b8/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2a9d795f7999a764aa7e432324d1e54aa7da7123/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1391,7 +1391,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/344d0ff1766a8581939695c451316710602ef0b8/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2a9d795f7999a764aa7e432324d1e54aa7da7123/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     return getfield(x, f)
 end
@@ -5601,11 +5601,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/344d0ff1766a8581939695c451316710602ef0b8/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/2a9d795f7999a764aa7e432324d1e54aa7da7123/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/344d0ff1766a8581939695c451316710602ef0b8/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/2a9d795f7999a764aa7e432324d1e54aa7da7123/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5628,7 +5628,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 28)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 80)
     f === :thread && return Ptr{aws_thread}(x + 84)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/344d0ff1766a8581939695c451316710602ef0b8/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/2a9d795f7999a764aa7e432324d1e54aa7da7123/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 188)
     return getfield(x, f)
 end

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1302,28 +1302,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/3a7d11083f463c8d0204eef2d1e0be4dd8922834/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/bf3f0394de44fee58e0e8c5020695fa4830e5e07/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/3a7d11083f463c8d0204eef2d1e0be4dd8922834/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/bf3f0394de44fee58e0e8c5020695fa4830e5e07/include/aws/io/io.h:18:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3a7d11083f463c8d0204eef2d1e0be4dd8922834/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bf3f0394de44fee58e0e8c5020695fa4830e5e07/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3a7d11083f463c8d0204eef2d1e0be4dd8922834/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3a7d11083f463c8d0204eef2d1e0be4dd8922834/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3a7d11083f463c8d0204eef2d1e0be4dd8922834/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/bf3f0394de44fee58e0e8c5020695fa4830e5e07/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/bf3f0394de44fee58e0e8c5020695fa4830e5e07/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bf3f0394de44fee58e0e8c5020695fa4830e5e07/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3a7d11083f463c8d0204eef2d1e0be4dd8922834/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bf3f0394de44fee58e0e8c5020695fa4830e5e07/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1337,7 +1337,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3a7d11083f463c8d0204eef2d1e0be4dd8922834/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/bf3f0394de44fee58e0e8c5020695fa4830e5e07/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     return getfield(x, f)
 end
@@ -5547,11 +5547,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/3a7d11083f463c8d0204eef2d1e0be4dd8922834/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/bf3f0394de44fee58e0e8c5020695fa4830e5e07/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/3a7d11083f463c8d0204eef2d1e0be4dd8922834/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/bf3f0394de44fee58e0e8c5020695fa4830e5e07/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5574,7 +5574,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3a7d11083f463c8d0204eef2d1e0be4dd8922834/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/bf3f0394de44fee58e0e8c5020695fa4830e5e07/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1302,28 +1302,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/02bc6f5baa096da817719d8e03a1409e31904092/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/9e4ab774f7e60fcf21ca7558aeca28ef0a4c3288/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/02bc6f5baa096da817719d8e03a1409e31904092/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/9e4ab774f7e60fcf21ca7558aeca28ef0a4c3288/include/aws/io/io.h:18:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/02bc6f5baa096da817719d8e03a1409e31904092/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e4ab774f7e60fcf21ca7558aeca28ef0a4c3288/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/02bc6f5baa096da817719d8e03a1409e31904092/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/02bc6f5baa096da817719d8e03a1409e31904092/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/02bc6f5baa096da817719d8e03a1409e31904092/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9e4ab774f7e60fcf21ca7558aeca28ef0a4c3288/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9e4ab774f7e60fcf21ca7558aeca28ef0a4c3288/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e4ab774f7e60fcf21ca7558aeca28ef0a4c3288/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/02bc6f5baa096da817719d8e03a1409e31904092/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e4ab774f7e60fcf21ca7558aeca28ef0a4c3288/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1337,7 +1337,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/02bc6f5baa096da817719d8e03a1409e31904092/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e4ab774f7e60fcf21ca7558aeca28ef0a4c3288/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     return getfield(x, f)
 end
@@ -5550,11 +5550,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/02bc6f5baa096da817719d8e03a1409e31904092/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/9e4ab774f7e60fcf21ca7558aeca28ef0a4c3288/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/02bc6f5baa096da817719d8e03a1409e31904092/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/9e4ab774f7e60fcf21ca7558aeca28ef0a4c3288/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5577,7 +5577,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/02bc6f5baa096da817719d8e03a1409e31904092/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/9e4ab774f7e60fcf21ca7558aeca28ef0a4c3288/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 336)
     return getfield(x, f)
 end

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1276,28 +1276,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/f787398706613f2aeb81ff51fe1e8cfa392dc46a/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/598b9ef104f44c75ca53c430919cec4a9741b586/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/f787398706613f2aeb81ff51fe1e8cfa392dc46a/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/598b9ef104f44c75ca53c430919cec4a9741b586/include/aws/io/io.h:18:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f787398706613f2aeb81ff51fe1e8cfa392dc46a/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/598b9ef104f44c75ca53c430919cec4a9741b586/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f787398706613f2aeb81ff51fe1e8cfa392dc46a/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f787398706613f2aeb81ff51fe1e8cfa392dc46a/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f787398706613f2aeb81ff51fe1e8cfa392dc46a/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/598b9ef104f44c75ca53c430919cec4a9741b586/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/598b9ef104f44c75ca53c430919cec4a9741b586/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/598b9ef104f44c75ca53c430919cec4a9741b586/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f787398706613f2aeb81ff51fe1e8cfa392dc46a/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/598b9ef104f44c75ca53c430919cec4a9741b586/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,7 +1311,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f787398706613f2aeb81ff51fe1e8cfa392dc46a/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/598b9ef104f44c75ca53c430919cec4a9741b586/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     return getfield(x, f)
 end
@@ -5521,11 +5521,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/f787398706613f2aeb81ff51fe1e8cfa392dc46a/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/598b9ef104f44c75ca53c430919cec4a9741b586/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/f787398706613f2aeb81ff51fe1e8cfa392dc46a/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/598b9ef104f44c75ca53c430919cec4a9741b586/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5548,7 +5548,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/f787398706613f2aeb81ff51fe1e8cfa392dc46a/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/598b9ef104f44c75ca53c430919cec4a9741b586/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1356,28 +1356,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/2d5b667622d0ad59d2d9adcf0e48ec67c9ecad15/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/0049777f161defc3843bb0e5bfd3b913fa63bfc1/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/2d5b667622d0ad59d2d9adcf0e48ec67c9ecad15/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/0049777f161defc3843bb0e5bfd3b913fa63bfc1/include/aws/io/io.h:18:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2d5b667622d0ad59d2d9adcf0e48ec67c9ecad15/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0049777f161defc3843bb0e5bfd3b913fa63bfc1/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2d5b667622d0ad59d2d9adcf0e48ec67c9ecad15/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2d5b667622d0ad59d2d9adcf0e48ec67c9ecad15/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2d5b667622d0ad59d2d9adcf0e48ec67c9ecad15/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0049777f161defc3843bb0e5bfd3b913fa63bfc1/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0049777f161defc3843bb0e5bfd3b913fa63bfc1/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0049777f161defc3843bb0e5bfd3b913fa63bfc1/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2d5b667622d0ad59d2d9adcf0e48ec67c9ecad15/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0049777f161defc3843bb0e5bfd3b913fa63bfc1/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1391,7 +1391,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2d5b667622d0ad59d2d9adcf0e48ec67c9ecad15/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0049777f161defc3843bb0e5bfd3b913fa63bfc1/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     return getfield(x, f)
 end
@@ -5601,11 +5601,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/2d5b667622d0ad59d2d9adcf0e48ec67c9ecad15/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/0049777f161defc3843bb0e5bfd3b913fa63bfc1/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/2d5b667622d0ad59d2d9adcf0e48ec67c9ecad15/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/0049777f161defc3843bb0e5bfd3b913fa63bfc1/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5628,7 +5628,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/2d5b667622d0ad59d2d9adcf0e48ec67c9ecad15/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/0049777f161defc3843bb0e5bfd3b913fa63bfc1/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1302,28 +1302,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/f8db7a74906eaf17226f22e4f1bd506e4c2dcc5e/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/c01c03012a8b5dcddbfed2b6a4dc3e4a2f72c4f7/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/f8db7a74906eaf17226f22e4f1bd506e4c2dcc5e/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/c01c03012a8b5dcddbfed2b6a4dc3e4a2f72c4f7/include/aws/io/io.h:18:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f8db7a74906eaf17226f22e4f1bd506e4c2dcc5e/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c01c03012a8b5dcddbfed2b6a4dc3e4a2f72c4f7/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f8db7a74906eaf17226f22e4f1bd506e4c2dcc5e/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f8db7a74906eaf17226f22e4f1bd506e4c2dcc5e/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f8db7a74906eaf17226f22e4f1bd506e4c2dcc5e/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c01c03012a8b5dcddbfed2b6a4dc3e4a2f72c4f7/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c01c03012a8b5dcddbfed2b6a4dc3e4a2f72c4f7/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c01c03012a8b5dcddbfed2b6a4dc3e4a2f72c4f7/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f8db7a74906eaf17226f22e4f1bd506e4c2dcc5e/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c01c03012a8b5dcddbfed2b6a4dc3e4a2f72c4f7/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1337,7 +1337,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f8db7a74906eaf17226f22e4f1bd506e4c2dcc5e/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c01c03012a8b5dcddbfed2b6a4dc3e4a2f72c4f7/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     return getfield(x, f)
 end
@@ -5547,11 +5547,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/f8db7a74906eaf17226f22e4f1bd506e4c2dcc5e/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/c01c03012a8b5dcddbfed2b6a4dc3e4a2f72c4f7/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/f8db7a74906eaf17226f22e4f1bd506e4c2dcc5e/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/c01c03012a8b5dcddbfed2b6a4dc3e4a2f72c4f7/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5574,7 +5574,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/f8db7a74906eaf17226f22e4f1bd506e4c2dcc5e/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/c01c03012a8b5dcddbfed2b6a4dc3e4a2f72c4f7/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 240)
     return getfield(x, f)
 end

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1302,28 +1302,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/860206bc5ca94cd4a879167ef82c8c93fac0dfc8/include/aws/io/io.h:18:5)
+    union (unnamed at /home/runner/.julia/artifacts/dd8b9f1fadcdea9532d1f7c17c98d9d551c9bc97/include/aws/io/io.h:18:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/860206bc5ca94cd4a879167ef82c8c93fac0dfc8/include/aws/io/io.h:18:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/dd8b9f1fadcdea9532d1f7c17c98d9d551c9bc97/include/aws/io/io.h:18:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/860206bc5ca94cd4a879167ef82c8c93fac0dfc8/include/aws/io/io.h:18:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dd8b9f1fadcdea9532d1f7c17c98d9d551c9bc97/include/aws/io/io.h:18:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/860206bc5ca94cd4a879167ef82c8c93fac0dfc8/include/aws/io/io.h:18:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/860206bc5ca94cd4a879167ef82c8c93fac0dfc8/include/aws/io/io.h:18:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/860206bc5ca94cd4a879167ef82c8c93fac0dfc8/include/aws/io/io.h:18:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/dd8b9f1fadcdea9532d1f7c17c98d9d551c9bc97/include/aws/io/io.h:18:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/dd8b9f1fadcdea9532d1f7c17c98d9d551c9bc97/include/aws/io/io.h:18:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dd8b9f1fadcdea9532d1f7c17c98d9d551c9bc97/include/aws/io/io.h:18:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/860206bc5ca94cd4a879167ef82c8c93fac0dfc8/include/aws/io/io.h:18:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dd8b9f1fadcdea9532d1f7c17c98d9d551c9bc97/include/aws/io/io.h:18:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1337,7 +1337,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/860206bc5ca94cd4a879167ef82c8c93fac0dfc8/include/aws/io/io.h:18:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dd8b9f1fadcdea9532d1f7c17c98d9d551c9bc97/include/aws/io/io.h:18:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     return getfield(x, f)
 end
@@ -5562,11 +5562,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/860206bc5ca94cd4a879167ef82c8c93fac0dfc8/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/dd8b9f1fadcdea9532d1f7c17c98d9d551c9bc97/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/860206bc5ca94cd4a879167ef82c8c93fac0dfc8/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/dd8b9f1fadcdea9532d1f7c17c98d9d551c9bc97/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5589,7 +5589,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/860206bc5ca94cd4a879167ef82c8c93fac0dfc8/include/aws/testing/async_stream_tester.h:55:5)"}(x + 192)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/dd8b9f1fadcdea9532d1f7c17c98d9d551c9bc97/include/aws/testing/async_stream_tester.h:55:5)"}(x + 192)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 248)
     return getfield(x, f)
 end


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_io_jll** to version **0.17.1**
- Updated **JuliaServices/LibAwsIO.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings