### PR TITLE
Update aws_c_io_jll to version 0.19.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsIO"
 uuid = "a5388770-19df-4151-b103-3d71de896ddf"
-version = "1.2.4"
+version = "1.2.5"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -13,7 +13,7 @@ Aqua = "0.7"
 CEnum = "0.5"
 LibAwsCal = "1.1"
 LibAwsCommon = "1.2"
-aws_c_io_jll = "=0.18.1"
+aws_c_io_jll = "=0.19.0"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -10,4 +10,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_io_jll = "=0.18.1"
+aws_c_io_jll = "=0.19.0"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/4219d275d0c156980a70fbdc8402050513a2f347/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/b5d84901a5f013e9054de4bbc189f35f493476c2/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/4219d275d0c156980a70fbdc8402050513a2f347/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/b5d84901a5f013e9054de4bbc189f35f493476c2/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4219d275d0c156980a70fbdc8402050513a2f347/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5d84901a5f013e9054de4bbc189f35f493476c2/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/4219d275d0c156980a70fbdc8402050513a2f347/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/4219d275d0c156980a70fbdc8402050513a2f347/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4219d275d0c156980a70fbdc8402050513a2f347/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b5d84901a5f013e9054de4bbc189f35f493476c2/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b5d84901a5f013e9054de4bbc189f35f493476c2/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5d84901a5f013e9054de4bbc189f35f493476c2/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4219d275d0c156980a70fbdc8402050513a2f347/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5d84901a5f013e9054de4bbc189f35f493476c2/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4219d275d0c156980a70fbdc8402050513a2f347/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5d84901a5f013e9054de4bbc189f35f493476c2/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -2478,7 +2478,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5767,11 +5767,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/4219d275d0c156980a70fbdc8402050513a2f347/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/b5d84901a5f013e9054de4bbc189f35f493476c2/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/4219d275d0c156980a70fbdc8402050513a2f347/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/b5d84901a5f013e9054de4bbc189f35f493476c2/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5794,7 +5794,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/4219d275d0c156980a70fbdc8402050513a2f347/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/b5d84901a5f013e9054de4bbc189f35f493476c2/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 336)
     return getfield(x, f)
 end

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/6e988470fba420c116160d1b818d6a9daf25be3e/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/6e988470fba420c116160d1b818d6a9daf25be3e/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e988470fba420c116160d1b818d6a9daf25be3e/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6e988470fba420c116160d1b818d6a9daf25be3e/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6e988470fba420c116160d1b818d6a9daf25be3e/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e988470fba420c116160d1b818d6a9daf25be3e/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e988470fba420c116160d1b818d6a9daf25be3e/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6e988470fba420c116160d1b818d6a9daf25be3e/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -2478,7 +2478,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5763,11 +5763,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/6e988470fba420c116160d1b818d6a9daf25be3e/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/6e988470fba420c116160d1b818d6a9daf25be3e/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5790,7 +5790,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6e988470fba420c116160d1b818d6a9daf25be3e/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 320)
     return getfield(x, f)
 end

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/4479345f0b2abc39c8983f41ab28ae000d1f2f45/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/4479345f0b2abc39c8983f41ab28ae000d1f2f45/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4479345f0b2abc39c8983f41ab28ae000d1f2f45/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/4479345f0b2abc39c8983f41ab28ae000d1f2f45/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/4479345f0b2abc39c8983f41ab28ae000d1f2f45/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4479345f0b2abc39c8983f41ab28ae000d1f2f45/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4479345f0b2abc39c8983f41ab28ae000d1f2f45/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/4479345f0b2abc39c8983f41ab28ae000d1f2f45/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -2532,7 +2532,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5817,11 +5817,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/4479345f0b2abc39c8983f41ab28ae000d1f2f45/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/4479345f0b2abc39c8983f41ab28ae000d1f2f45/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5844,7 +5844,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/4479345f0b2abc39c8983f41ab28ae000d1f2f45/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/dc036925ae2332bb4f762a4bcc3ad10d844b8c43/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/dc036925ae2332bb4f762a4bcc3ad10d844b8c43/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dc036925ae2332bb4f762a4bcc3ad10d844b8c43/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/dc036925ae2332bb4f762a4bcc3ad10d844b8c43/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/dc036925ae2332bb4f762a4bcc3ad10d844b8c43/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dc036925ae2332bb4f762a4bcc3ad10d844b8c43/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dc036925ae2332bb4f762a4bcc3ad10d844b8c43/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dc036925ae2332bb4f762a4bcc3ad10d844b8c43/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -2478,7 +2478,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5763,11 +5763,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/dc036925ae2332bb4f762a4bcc3ad10d844b8c43/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/dc036925ae2332bb4f762a4bcc3ad10d844b8c43/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5790,7 +5790,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 32)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 88)
     f === :thread && return Ptr{aws_thread}(x + 92)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/dc036925ae2332bb4f762a4bcc3ad10d844b8c43/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 208)
     return getfield(x, f)
 end

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/57d6142d653636560af5eda0db8cb5697249065c/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/57d6142d653636560af5eda0db8cb5697249065c/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/57d6142d653636560af5eda0db8cb5697249065c/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/57d6142d653636560af5eda0db8cb5697249065c/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/57d6142d653636560af5eda0db8cb5697249065c/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/57d6142d653636560af5eda0db8cb5697249065c/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/57d6142d653636560af5eda0db8cb5697249065c/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/57d6142d653636560af5eda0db8cb5697249065c/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -2532,7 +2532,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5817,11 +5817,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/57d6142d653636560af5eda0db8cb5697249065c/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/57d6142d653636560af5eda0db8cb5697249065c/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5844,7 +5844,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 32)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 88)
     f === :thread && return Ptr{aws_thread}(x + 92)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/57d6142d653636560af5eda0db8cb5697249065c/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 196)
     return getfield(x, f)
 end

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/06f2a72d8271a625d7e8c883c6f255838e259090/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/06f2a72d8271a625d7e8c883c6f255838e259090/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/06f2a72d8271a625d7e8c883c6f255838e259090/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/06f2a72d8271a625d7e8c883c6f255838e259090/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/06f2a72d8271a625d7e8c883c6f255838e259090/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/06f2a72d8271a625d7e8c883c6f255838e259090/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/06f2a72d8271a625d7e8c883c6f255838e259090/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/06f2a72d8271a625d7e8c883c6f255838e259090/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -2478,7 +2478,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5763,11 +5763,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/06f2a72d8271a625d7e8c883c6f255838e259090/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/06f2a72d8271a625d7e8c883c6f255838e259090/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5790,7 +5790,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 28)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 80)
     f === :thread && return Ptr{aws_thread}(x + 84)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/06f2a72d8271a625d7e8c883c6f255838e259090/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 188)
     return getfield(x, f)
 end

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/1d543e0a2256c9324cd4169bdff177b0b7ba1e84/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/1d543e0a2256c9324cd4169bdff177b0b7ba1e84/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1d543e0a2256c9324cd4169bdff177b0b7ba1e84/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1d543e0a2256c9324cd4169bdff177b0b7ba1e84/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1d543e0a2256c9324cd4169bdff177b0b7ba1e84/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1d543e0a2256c9324cd4169bdff177b0b7ba1e84/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1d543e0a2256c9324cd4169bdff177b0b7ba1e84/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1d543e0a2256c9324cd4169bdff177b0b7ba1e84/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -2532,7 +2532,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5817,11 +5817,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/1d543e0a2256c9324cd4169bdff177b0b7ba1e84/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/1d543e0a2256c9324cd4169bdff177b0b7ba1e84/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5844,7 +5844,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 28)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 80)
     f === :thread && return Ptr{aws_thread}(x + 84)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/1d543e0a2256c9324cd4169bdff177b0b7ba1e84/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 188)
     return getfield(x, f)
 end

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/a6090dfa374d71622f1be370fd6d9c75133da058/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/a6090dfa374d71622f1be370fd6d9c75133da058/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6090dfa374d71622f1be370fd6d9c75133da058/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a6090dfa374d71622f1be370fd6d9c75133da058/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a6090dfa374d71622f1be370fd6d9c75133da058/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6090dfa374d71622f1be370fd6d9c75133da058/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6090dfa374d71622f1be370fd6d9c75133da058/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6090dfa374d71622f1be370fd6d9c75133da058/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -2478,7 +2478,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5763,11 +5763,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/a6090dfa374d71622f1be370fd6d9c75133da058/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/a6090dfa374d71622f1be370fd6d9c75133da058/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5790,7 +5790,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a6090dfa374d71622f1be370fd6d9c75133da058/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/9fbb5234d4445f6025f34f761fa34e65982745fe/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/6f67c1fbb4afbbb74e9e5b4bfe15c275f9a79ada/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/9fbb5234d4445f6025f34f761fa34e65982745fe/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/6f67c1fbb4afbbb74e9e5b4bfe15c275f9a79ada/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9fbb5234d4445f6025f34f761fa34e65982745fe/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6f67c1fbb4afbbb74e9e5b4bfe15c275f9a79ada/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9fbb5234d4445f6025f34f761fa34e65982745fe/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9fbb5234d4445f6025f34f761fa34e65982745fe/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9fbb5234d4445f6025f34f761fa34e65982745fe/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6f67c1fbb4afbbb74e9e5b4bfe15c275f9a79ada/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6f67c1fbb4afbbb74e9e5b4bfe15c275f9a79ada/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6f67c1fbb4afbbb74e9e5b4bfe15c275f9a79ada/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9fbb5234d4445f6025f34f761fa34e65982745fe/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6f67c1fbb4afbbb74e9e5b4bfe15c275f9a79ada/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9fbb5234d4445f6025f34f761fa34e65982745fe/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6f67c1fbb4afbbb74e9e5b4bfe15c275f9a79ada/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -2478,7 +2478,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5767,11 +5767,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/9fbb5234d4445f6025f34f761fa34e65982745fe/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/6f67c1fbb4afbbb74e9e5b4bfe15c275f9a79ada/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/9fbb5234d4445f6025f34f761fa34e65982745fe/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/6f67c1fbb4afbbb74e9e5b4bfe15c275f9a79ada/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5794,7 +5794,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/9fbb5234d4445f6025f34f761fa34e65982745fe/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6f67c1fbb4afbbb74e9e5b4bfe15c275f9a79ada/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 336)
     return getfield(x, f)
 end

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1285,28 +1285,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e5a77f9e1125aab123cd4799d55c9a998396b52b/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e5a77f9e1125aab123cd4799d55c9a998396b52b/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e5a77f9e1125aab123cd4799d55c9a998396b52b/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e5a77f9e1125aab123cd4799d55c9a998396b52b/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e5a77f9e1125aab123cd4799d55c9a998396b52b/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e5a77f9e1125aab123cd4799d55c9a998396b52b/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e5a77f9e1125aab123cd4799d55c9a998396b52b/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1326,7 +1326,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e5a77f9e1125aab123cd4799d55c9a998396b52b/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -2452,7 +2452,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5737,11 +5737,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/e5a77f9e1125aab123cd4799d55c9a998396b52b/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/e5a77f9e1125aab123cd4799d55c9a998396b52b/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5764,7 +5764,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/e5a77f9e1125aab123cd4799d55c9a998396b52b/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/58eed10b06aa241711927d342c2f6c03276ad8af/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/58eed10b06aa241711927d342c2f6c03276ad8af/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/58eed10b06aa241711927d342c2f6c03276ad8af/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/58eed10b06aa241711927d342c2f6c03276ad8af/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/58eed10b06aa241711927d342c2f6c03276ad8af/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/58eed10b06aa241711927d342c2f6c03276ad8af/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/58eed10b06aa241711927d342c2f6c03276ad8af/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/58eed10b06aa241711927d342c2f6c03276ad8af/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -2532,7 +2532,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5817,11 +5817,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/58eed10b06aa241711927d342c2f6c03276ad8af/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/58eed10b06aa241711927d342c2f6c03276ad8af/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5844,7 +5844,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/58eed10b06aa241711927d342c2f6c03276ad8af/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/5367f1cebfdf3e845e0b0f3f47e86a33dcc8acf3/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/fd77dd59cd00e908bd83e35b6c8e9deb8326faa9/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/5367f1cebfdf3e845e0b0f3f47e86a33dcc8acf3/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/fd77dd59cd00e908bd83e35b6c8e9deb8326faa9/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5367f1cebfdf3e845e0b0f3f47e86a33dcc8acf3/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fd77dd59cd00e908bd83e35b6c8e9deb8326faa9/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5367f1cebfdf3e845e0b0f3f47e86a33dcc8acf3/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5367f1cebfdf3e845e0b0f3f47e86a33dcc8acf3/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5367f1cebfdf3e845e0b0f3f47e86a33dcc8acf3/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/fd77dd59cd00e908bd83e35b6c8e9deb8326faa9/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/fd77dd59cd00e908bd83e35b6c8e9deb8326faa9/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fd77dd59cd00e908bd83e35b6c8e9deb8326faa9/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5367f1cebfdf3e845e0b0f3f47e86a33dcc8acf3/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fd77dd59cd00e908bd83e35b6c8e9deb8326faa9/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5367f1cebfdf3e845e0b0f3f47e86a33dcc8acf3/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fd77dd59cd00e908bd83e35b6c8e9deb8326faa9/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -2478,7 +2478,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5763,11 +5763,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/5367f1cebfdf3e845e0b0f3f47e86a33dcc8acf3/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/fd77dd59cd00e908bd83e35b6c8e9deb8326faa9/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/5367f1cebfdf3e845e0b0f3f47e86a33dcc8acf3/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/fd77dd59cd00e908bd83e35b6c8e9deb8326faa9/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5790,7 +5790,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/5367f1cebfdf3e845e0b0f3f47e86a33dcc8acf3/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/fd77dd59cd00e908bd83e35b6c8e9deb8326faa9/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 240)
     return getfield(x, f)
 end

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/350ce54b9b8757e6b325b052970127945d9e0a77/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/daad4312a5866c0281466583fedcb57c13648f51/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/350ce54b9b8757e6b325b052970127945d9e0a77/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/daad4312a5866c0281466583fedcb57c13648f51/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/350ce54b9b8757e6b325b052970127945d9e0a77/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/daad4312a5866c0281466583fedcb57c13648f51/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/350ce54b9b8757e6b325b052970127945d9e0a77/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/350ce54b9b8757e6b325b052970127945d9e0a77/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/350ce54b9b8757e6b325b052970127945d9e0a77/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/daad4312a5866c0281466583fedcb57c13648f51/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/daad4312a5866c0281466583fedcb57c13648f51/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/daad4312a5866c0281466583fedcb57c13648f51/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/350ce54b9b8757e6b325b052970127945d9e0a77/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/daad4312a5866c0281466583fedcb57c13648f51/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/350ce54b9b8757e6b325b052970127945d9e0a77/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/daad4312a5866c0281466583fedcb57c13648f51/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -2478,7 +2478,7 @@ mutable struct aws_future_void end
 """
     aws_future_void_new(alloc)
 
-aws\\_future<void>
+aws\\_future<void> See top of future.h for docs.
 
 ### Prototype
 ```c
@@ -5778,11 +5778,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/350ce54b9b8757e6b325b052970127945d9e0a77/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/daad4312a5866c0281466583fedcb57c13648f51/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/350ce54b9b8757e6b325b052970127945d9e0a77/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/daad4312a5866c0281466583fedcb57c13648f51/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5805,7 +5805,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/350ce54b9b8757e6b325b052970127945d9e0a77/include/aws/testing/async_stream_tester.h:55:5)"}(x + 192)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/daad4312a5866c0281466583fedcb57c13648f51/include/aws/testing/async_stream_tester.h:55:5)"}(x + 192)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 248)
     return getfield(x, f)
 end


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_io_jll** to version **0.19.0**
- Updated **JuliaServices/LibAwsIO.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings