### PR TITLE
Update aws_c_io_jll to version 0.20.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsIO"
 uuid = "a5388770-19df-4151-b103-3d71de896ddf"
-version = "1.2.6"
+version = "1.2.7"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -13,7 +13,7 @@ Aqua = "0.7"
 CEnum = "0.5"
 LibAwsCal = "1.1.5"
 LibAwsCommon = "1.2.4"
-aws_c_io_jll = "=0.19.1"
+aws_c_io_jll = "=0.20.1"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -10,4 +10,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_io_jll = "=0.19.1"
+aws_c_io_jll = "=0.20.1"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e495e794ceeb771a8d751fc394380b6b5fc8fadf/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e495e794ceeb771a8d751fc394380b6b5fc8fadf/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e495e794ceeb771a8d751fc394380b6b5fc8fadf/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e495e794ceeb771a8d751fc394380b6b5fc8fadf/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e495e794ceeb771a8d751fc394380b6b5fc8fadf/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e495e794ceeb771a8d751fc394380b6b5fc8fadf/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e495e794ceeb771a8d751fc394380b6b5fc8fadf/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e495e794ceeb771a8d751fc394380b6b5fc8fadf/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1507,7 +1507,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1661,6 +1660,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5767,11 +5796,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/e495e794ceeb771a8d751fc394380b6b5fc8fadf/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/e495e794ceeb771a8d751fc394380b6b5fc8fadf/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5794,7 +5823,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/e495e794ceeb771a8d751fc394380b6b5fc8fadf/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 336)
     return getfield(x, f)
 end

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1507,7 +1507,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1661,6 +1660,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5763,11 +5792,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5790,7 +5819,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/92f58fdfe4b44ecc03658289d3308cc19ff31d94/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 320)
     return getfield(x, f)
 end

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1561,7 +1561,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1715,6 +1714,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5817,11 +5846,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5844,7 +5873,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/b45604603276420185dcc755d14507ed97a02f9c/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -1507,7 +1507,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1661,6 +1660,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5763,11 +5792,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5790,7 +5819,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 32)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 88)
     f === :thread && return Ptr{aws_thread}(x + 92)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/95d8773f338ef04a0d24ddd9e5b05bd51f045fee/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 208)
     return getfield(x, f)
 end

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -1561,7 +1561,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1715,6 +1714,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5817,11 +5846,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5844,7 +5873,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 32)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 88)
     f === :thread && return Ptr{aws_thread}(x + 92)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/353589a6c505dbecbb767128f7bfed0917156a04/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 196)
     return getfield(x, f)
 end

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -1507,7 +1507,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1661,6 +1660,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5763,11 +5792,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5790,7 +5819,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 28)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 80)
     f === :thread && return Ptr{aws_thread}(x + 84)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/8a76eabf7d5873397c5933e44b95f9beebbf4197/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 188)
     return getfield(x, f)
 end

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -1561,7 +1561,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1715,6 +1714,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5817,11 +5846,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5844,7 +5873,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 28)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 80)
     f === :thread && return Ptr{aws_thread}(x + 84)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/0c42965d8c884310ff5b02fb0f0124e4e5e558ec/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 188)
     return getfield(x, f)
 end

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1507,7 +1507,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1661,6 +1660,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5763,11 +5792,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5790,7 +5819,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a6a143135208f68e22b33fe440c5f982f0f29b52/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/0bc335540592fc0b5fdaad3748137aaa6b2279cd/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/0bc335540592fc0b5fdaad3748137aaa6b2279cd/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0bc335540592fc0b5fdaad3748137aaa6b2279cd/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0bc335540592fc0b5fdaad3748137aaa6b2279cd/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0bc335540592fc0b5fdaad3748137aaa6b2279cd/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0bc335540592fc0b5fdaad3748137aaa6b2279cd/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0bc335540592fc0b5fdaad3748137aaa6b2279cd/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0bc335540592fc0b5fdaad3748137aaa6b2279cd/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1507,7 +1507,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1661,6 +1660,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5767,11 +5796,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/0bc335540592fc0b5fdaad3748137aaa6b2279cd/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/0bc335540592fc0b5fdaad3748137aaa6b2279cd/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5794,7 +5823,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/0bc335540592fc0b5fdaad3748137aaa6b2279cd/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 336)
     return getfield(x, f)
 end

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1285,28 +1285,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1326,7 +1326,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1481,7 +1481,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1635,6 +1634,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5737,11 +5766,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5764,7 +5793,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/838ab39060e3f17c71ef884e433bc1c9e1fdf924/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1561,7 +1561,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1715,6 +1714,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5817,11 +5846,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5844,7 +5873,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6a32761de76651c5855f219555964060d062c3b6/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/9a3d642422541e213b1ff6d9134ddbeaf66b8e1b/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/9a3d642422541e213b1ff6d9134ddbeaf66b8e1b/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9a3d642422541e213b1ff6d9134ddbeaf66b8e1b/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9a3d642422541e213b1ff6d9134ddbeaf66b8e1b/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9a3d642422541e213b1ff6d9134ddbeaf66b8e1b/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9a3d642422541e213b1ff6d9134ddbeaf66b8e1b/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9a3d642422541e213b1ff6d9134ddbeaf66b8e1b/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9a3d642422541e213b1ff6d9134ddbeaf66b8e1b/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1507,7 +1507,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1661,6 +1660,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5763,11 +5792,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/9a3d642422541e213b1ff6d9134ddbeaf66b8e1b/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/9a3d642422541e213b1ff6d9134ddbeaf66b8e1b/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5790,7 +5819,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/9a3d642422541e213b1ff6d9134ddbeaf66b8e1b/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 240)
     return getfield(x, f)
 end

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/ba0b2a29a05f923b70f84efedc8f02a018681782/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/ba0b2a29a05f923b70f84efedc8f02a018681782/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ba0b2a29a05f923b70f84efedc8f02a018681782/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/ba0b2a29a05f923b70f84efedc8f02a018681782/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/ba0b2a29a05f923b70f84efedc8f02a018681782/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ba0b2a29a05f923b70f84efedc8f02a018681782/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ba0b2a29a05f923b70f84efedc8f02a018681782/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ba0b2a29a05f923b70f84efedc8f02a018681782/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1507,7 +1507,6 @@ struct aws_event_loop_vtable
     subscribe_to_io_events::Ptr{Cvoid}
     unsubscribe_from_io_events::Ptr{Cvoid}
     free_io_event_resources::Ptr{Cvoid}
-    get_base_event_loop_group::Ptr{Cvoid}
     is_on_callers_thread::Ptr{Cvoid}
 end
 
@@ -1661,6 +1660,36 @@ void aws_event_loop_group_release(struct aws_event_loop_group *el_group);
 """
 function aws_event_loop_group_release(el_group)
     ccall((:aws_event_loop_group_release, libaws_c_io), Cvoid, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_acquire_from_event_loop(event_loop)
+
+Increments the reference count on the event loop group from event loop, allowing the caller to take a reference to it.
+
+Returns the base event loop group of the event loop, or null if the event loop does not belong to a group.
+
+### Prototype
+```c
+struct aws_event_loop_group *aws_event_loop_group_acquire_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_acquire_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_acquire_from_event_loop, libaws_c_io), Ptr{aws_event_loop_group}, (Ptr{aws_event_loop},), event_loop)
+end
+
+"""
+    aws_event_loop_group_release_from_event_loop(event_loop)
+
+Decrements the ref count of the event loop's base event loop group. When the ref count drops to zero, the event loop group will be destroyed.
+
+### Prototype
+```c
+void aws_event_loop_group_release_from_event_loop(struct aws_event_loop *event_loop);
+```
+"""
+function aws_event_loop_group_release_from_event_loop(event_loop)
+    ccall((:aws_event_loop_group_release_from_event_loop, libaws_c_io), Cvoid, (Ptr{aws_event_loop},), event_loop)
 end
 
 """
@@ -5778,11 +5807,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/ba0b2a29a05f923b70f84efedc8f02a018681782/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/ba0b2a29a05f923b70f84efedc8f02a018681782/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5805,7 +5834,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/ba0b2a29a05f923b70f84efedc8f02a018681782/include/aws/testing/async_stream_tester.h:55:5)"}(x + 192)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/testing/async_stream_tester.h:55:5)"}(x + 192)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 248)
     return getfield(x, f)
 end


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_io_jll** to version **0.20.1**
- Updated **JuliaServices/LibAwsIO.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings