### PR TITLE
Update aws_c_io_jll to version 0.21.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsIO"
 uuid = "a5388770-19df-4151-b103-3d71de896ddf"
-version = "1.2.7"
+version = "1.2.8"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -13,7 +13,7 @@ Aqua = "0.7"
 CEnum = "0.5"
 LibAwsCal = "1.1.5"
 LibAwsCommon = "1.2.4"
-aws_c_io_jll = "=0.20.1"
+aws_c_io_jll = "=0.21.1"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -10,4 +10,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_io_jll = "=0.20.1"
+aws_c_io_jll = "=0.21.1"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/066e61d1aa5ba887f608a3697a09ae9d1b3e08b2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/301d0646ddcf6d551807fdd1177c9f5f57ded4ee/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/301d0646ddcf6d551807fdd1177c9f5f57ded4ee/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/301d0646ddcf6d551807fdd1177c9f5f57ded4ee/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/301d0646ddcf6d551807fdd1177c9f5f57ded4ee/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/301d0646ddcf6d551807fdd1177c9f5f57ded4ee/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/301d0646ddcf6d551807fdd1177c9f5f57ded4ee/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/301d0646ddcf6d551807fdd1177c9f5f57ded4ee/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/301d0646ddcf6d551807fdd1177c9f5f57ded4ee/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -4783,6 +4783,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5796,11 +5797,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/301d0646ddcf6d551807fdd1177c9f5f57ded4ee/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/301d0646ddcf6d551807fdd1177c9f5f57ded4ee/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5823,7 +5824,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/322dee3203ca8b7472ba993a54bae6d69ec42e73/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/301d0646ddcf6d551807fdd1177c9f5f57ded4ee/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 336)
     return getfield(x, f)
 end

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/38395a253c26ecafa48629dd5ecacb71b1fe43ec/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/3fe70bd6746f07f7b1260f007fe9774ddebce4f1/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/3fe70bd6746f07f7b1260f007fe9774ddebce4f1/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3fe70bd6746f07f7b1260f007fe9774ddebce4f1/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3fe70bd6746f07f7b1260f007fe9774ddebce4f1/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3fe70bd6746f07f7b1260f007fe9774ddebce4f1/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3fe70bd6746f07f7b1260f007fe9774ddebce4f1/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3fe70bd6746f07f7b1260f007fe9774ddebce4f1/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3fe70bd6746f07f7b1260f007fe9774ddebce4f1/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -4783,6 +4783,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5792,11 +5793,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/3fe70bd6746f07f7b1260f007fe9774ddebce4f1/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/3fe70bd6746f07f7b1260f007fe9774ddebce4f1/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5819,7 +5820,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a46931902273008195ae4db56e96f1d98e69521c/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/3fe70bd6746f07f7b1260f007fe9774ddebce4f1/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 320)
     return getfield(x, f)
 end

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/add0be079c4e69879efc9d1fe464deb55b1da9df/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/d1e3c583488c02f10f5193cd4662e63fe3aa320e/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/d1e3c583488c02f10f5193cd4662e63fe3aa320e/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d1e3c583488c02f10f5193cd4662e63fe3aa320e/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d1e3c583488c02f10f5193cd4662e63fe3aa320e/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d1e3c583488c02f10f5193cd4662e63fe3aa320e/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d1e3c583488c02f10f5193cd4662e63fe3aa320e/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d1e3c583488c02f10f5193cd4662e63fe3aa320e/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d1e3c583488c02f10f5193cd4662e63fe3aa320e/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -4837,6 +4837,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5846,11 +5847,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/d1e3c583488c02f10f5193cd4662e63fe3aa320e/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/d1e3c583488c02f10f5193cd4662e63fe3aa320e/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5873,7 +5874,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/d97419adb573360dfefd4af812530b4e3a9ea552/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/d1e3c583488c02f10f5193cd4662e63fe3aa320e/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc28580483e84656cc3c8a64dd8e7d13b9263a15/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/f688491515d227371a942fa2cefb738a7093304b/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/f688491515d227371a942fa2cefb738a7093304b/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f688491515d227371a942fa2cefb738a7093304b/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f688491515d227371a942fa2cefb738a7093304b/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f688491515d227371a942fa2cefb738a7093304b/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f688491515d227371a942fa2cefb738a7093304b/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f688491515d227371a942fa2cefb738a7093304b/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f688491515d227371a942fa2cefb738a7093304b/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -4783,6 +4783,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5792,11 +5793,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/f688491515d227371a942fa2cefb738a7093304b/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/f688491515d227371a942fa2cefb738a7093304b/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5819,7 +5820,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 32)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 88)
     f === :thread && return Ptr{aws_thread}(x + 92)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/27aefb1c31e47b00ac8ddae0e0c6b92f0d58bd8a/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/f688491515d227371a942fa2cefb738a7093304b/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 208)
     return getfield(x, f)
 end

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/76450355fe8683d5a00b7ff05df6cc8fcf2805a6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/9bc7d1e66784304828571aef81e11e68ef910613/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/9bc7d1e66784304828571aef81e11e68ef910613/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9bc7d1e66784304828571aef81e11e68ef910613/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9bc7d1e66784304828571aef81e11e68ef910613/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9bc7d1e66784304828571aef81e11e68ef910613/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9bc7d1e66784304828571aef81e11e68ef910613/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9bc7d1e66784304828571aef81e11e68ef910613/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9bc7d1e66784304828571aef81e11e68ef910613/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -4837,6 +4837,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5846,11 +5847,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/9bc7d1e66784304828571aef81e11e68ef910613/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/9bc7d1e66784304828571aef81e11e68ef910613/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5873,7 +5874,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 32)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 88)
     f === :thread && return Ptr{aws_thread}(x + 92)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/2a589447c5ac0bb76c2c2be90f63d5fa4d8e5487/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/9bc7d1e66784304828571aef81e11e68ef910613/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 196)
     return getfield(x, f)
 end

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/418bca0a928226ba18856b04a407cb9f14d926a1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/fb8d3cd3ae1e98825091dfe32281fb71c1f07de0/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/fb8d3cd3ae1e98825091dfe32281fb71c1f07de0/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fb8d3cd3ae1e98825091dfe32281fb71c1f07de0/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/fb8d3cd3ae1e98825091dfe32281fb71c1f07de0/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/fb8d3cd3ae1e98825091dfe32281fb71c1f07de0/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fb8d3cd3ae1e98825091dfe32281fb71c1f07de0/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fb8d3cd3ae1e98825091dfe32281fb71c1f07de0/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fb8d3cd3ae1e98825091dfe32281fb71c1f07de0/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -4783,6 +4783,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5792,11 +5793,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/fb8d3cd3ae1e98825091dfe32281fb71c1f07de0/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/fb8d3cd3ae1e98825091dfe32281fb71c1f07de0/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5819,7 +5820,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 28)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 80)
     f === :thread && return Ptr{aws_thread}(x + 84)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/83f09eeceb4a3e5704ef922a8f0aa878cbba0621/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/fb8d3cd3ae1e98825091dfe32281fb71c1f07de0/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 188)
     return getfield(x, f)
 end

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e36ed32cc0043fa5cc37b4542dddc718429130d5/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/5002a65b3a8d7f4eef4ed00157b2676a1b89dd30/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/5002a65b3a8d7f4eef4ed00157b2676a1b89dd30/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5002a65b3a8d7f4eef4ed00157b2676a1b89dd30/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5002a65b3a8d7f4eef4ed00157b2676a1b89dd30/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5002a65b3a8d7f4eef4ed00157b2676a1b89dd30/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5002a65b3a8d7f4eef4ed00157b2676a1b89dd30/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5002a65b3a8d7f4eef4ed00157b2676a1b89dd30/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5002a65b3a8d7f4eef4ed00157b2676a1b89dd30/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -4837,6 +4837,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5846,11 +5847,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/5002a65b3a8d7f4eef4ed00157b2676a1b89dd30/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/5002a65b3a8d7f4eef4ed00157b2676a1b89dd30/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5873,7 +5874,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 28)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 80)
     f === :thread && return Ptr{aws_thread}(x + 84)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/a7e0209c8708e2f5ebdfac2a32fc2065641a0596/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/5002a65b3a8d7f4eef4ed00157b2676a1b89dd30/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 188)
     return getfield(x, f)
 end

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/556f49ed63326a97e72131fd42db2ac11693cd67/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/174eed4d5befa24cede93f61c66acd461eb2ef30/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/174eed4d5befa24cede93f61c66acd461eb2ef30/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/174eed4d5befa24cede93f61c66acd461eb2ef30/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/174eed4d5befa24cede93f61c66acd461eb2ef30/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/174eed4d5befa24cede93f61c66acd461eb2ef30/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/174eed4d5befa24cede93f61c66acd461eb2ef30/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/174eed4d5befa24cede93f61c66acd461eb2ef30/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/174eed4d5befa24cede93f61c66acd461eb2ef30/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -4783,6 +4783,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5792,11 +5793,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/174eed4d5befa24cede93f61c66acd461eb2ef30/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/174eed4d5befa24cede93f61c66acd461eb2ef30/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5819,7 +5820,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/5cc2f4c823a0644b7c233b6dc7713d2ebc051aee/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/174eed4d5befa24cede93f61c66acd461eb2ef30/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/ec92e041cea745d3a19668267439788457587b38/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/0cdb340f747018799bd486bbb23fb8c1125d030d/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/0cdb340f747018799bd486bbb23fb8c1125d030d/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0cdb340f747018799bd486bbb23fb8c1125d030d/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/0cdb340f747018799bd486bbb23fb8c1125d030d/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/0cdb340f747018799bd486bbb23fb8c1125d030d/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0cdb340f747018799bd486bbb23fb8c1125d030d/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0cdb340f747018799bd486bbb23fb8c1125d030d/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/0cdb340f747018799bd486bbb23fb8c1125d030d/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -4783,6 +4783,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5796,11 +5797,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/0cdb340f747018799bd486bbb23fb8c1125d030d/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/0cdb340f747018799bd486bbb23fb8c1125d030d/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5823,7 +5824,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/65b7c5ccd51445e4d59baf463b71d53090e55511/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/0cdb340f747018799bd486bbb23fb8c1125d030d/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 336)
     return getfield(x, f)
 end

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1285,28 +1285,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/974c6c081fed6f541d2aa821fc5910d98aae479d/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/974c6c081fed6f541d2aa821fc5910d98aae479d/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/974c6c081fed6f541d2aa821fc5910d98aae479d/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/974c6c081fed6f541d2aa821fc5910d98aae479d/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/974c6c081fed6f541d2aa821fc5910d98aae479d/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/974c6c081fed6f541d2aa821fc5910d98aae479d/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/974c6c081fed6f541d2aa821fc5910d98aae479d/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1326,7 +1326,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/974c6c081fed6f541d2aa821fc5910d98aae479d/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -4757,6 +4757,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5766,11 +5767,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/974c6c081fed6f541d2aa821fc5910d98aae479d/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/974c6c081fed6f541d2aa821fc5910d98aae479d/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5793,7 +5794,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/98f6a88182f0eafe03af44882072ec40b4a88235/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/974c6c081fed6f541d2aa821fc5910d98aae479d/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/17b498a004940da9270bdba893c3c6a9cf9c3c28/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/5d1e499f4768a432e0c769ca014ae4db8f2de47d/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/5d1e499f4768a432e0c769ca014ae4db8f2de47d/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5d1e499f4768a432e0c769ca014ae4db8f2de47d/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5d1e499f4768a432e0c769ca014ae4db8f2de47d/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5d1e499f4768a432e0c769ca014ae4db8f2de47d/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5d1e499f4768a432e0c769ca014ae4db8f2de47d/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5d1e499f4768a432e0c769ca014ae4db8f2de47d/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5d1e499f4768a432e0c769ca014ae4db8f2de47d/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -4837,6 +4837,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5846,11 +5847,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/5d1e499f4768a432e0c769ca014ae4db8f2de47d/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/5d1e499f4768a432e0c769ca014ae4db8f2de47d/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5873,7 +5874,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/e2b5a04037905681edf795f418993f40f297cdea/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/5d1e499f4768a432e0c769ca014ae4db8f2de47d/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cc33d56f1e16e279516c73623db3b661c5b72efe/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/f16e2df57330eaf7781f1b677cbbd84571d5d0f4/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/f16e2df57330eaf7781f1b677cbbd84571d5d0f4/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f16e2df57330eaf7781f1b677cbbd84571d5d0f4/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f16e2df57330eaf7781f1b677cbbd84571d5d0f4/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f16e2df57330eaf7781f1b677cbbd84571d5d0f4/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f16e2df57330eaf7781f1b677cbbd84571d5d0f4/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f16e2df57330eaf7781f1b677cbbd84571d5d0f4/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f16e2df57330eaf7781f1b677cbbd84571d5d0f4/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -4783,6 +4783,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5792,11 +5793,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/f16e2df57330eaf7781f1b677cbbd84571d5d0f4/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/f16e2df57330eaf7781f1b677cbbd84571d5d0f4/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5819,7 +5820,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/93526ace4f05c0cd8cd2568e3df5d32e02109f5b/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/f16e2df57330eaf7781f1b677cbbd84571d5d0f4/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 240)
     return getfield(x, f)
 end

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/40e060528f20f56fc255c64ec468bceb7581529c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/5c9be34e52414192866a7a8f6c088e13276688f9/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/5c9be34e52414192866a7a8f6c088e13276688f9/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5c9be34e52414192866a7a8f6c088e13276688f9/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5c9be34e52414192866a7a8f6c088e13276688f9/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5c9be34e52414192866a7a8f6c088e13276688f9/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5c9be34e52414192866a7a8f6c088e13276688f9/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5c9be34e52414192866a7a8f6c088e13276688f9/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5c9be34e52414192866a7a8f6c088e13276688f9/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -4797,6 +4797,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 = 6
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5807,11 +5808,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/5c9be34e52414192866a7a8f6c088e13276688f9/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/5c9be34e52414192866a7a8f6c088e13276688f9/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5834,7 +5835,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/fdddd3bdd5543007766f3705d2f7fff4209a487d/include/aws/testing/async_stream_tester.h:55:5)"}(x + 192)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/5c9be34e52414192866a7a8f6c088e13276688f9/include/aws/testing/async_stream_tester.h:55:5)"}(x + 192)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 248)
     return getfield(x, f)
 end


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_io_jll** to version **0.21.1**
- Updated **JuliaServices/LibAwsIO.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings