### PR TITLE
Update aws_c_io_jll to version 0.22.0

### DIFF
--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1555,6 +1555,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1612,6 +1613,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1555,6 +1555,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1612,6 +1613,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1555,6 +1555,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1612,6 +1613,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1475,6 +1475,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1532,6 +1533,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1555,6 +1555,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1612,6 +1613,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_io_jll** to version **0.22.0**
- Updated **JuliaServices/LibAwsIO.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings