### PR TITLE
Update aws_c_io_jll to version 0.23.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsIO"
 uuid = "a5388770-19df-4151-b103-3d71de896ddf"
-version = "1.2.9"
+version = "1.2.10"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -13,7 +13,7 @@ Aqua = "0.7,0.8"
 CEnum = "0.5"
 LibAwsCal = "1.1.5"
 LibAwsCommon = "1.2.4"
-aws_c_io_jll = "=0.21.4"
+aws_c_io_jll = "=0.23.2"
 julia = "1.6"
 Test = "1.9"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -10,4 +10,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_io_jll = "=0.21.4"
+aws_c_io_jll = "=0.23.2"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1a010ff8b8278069f288fbf362d6550c9c6f09ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/f3e7f78fcbb15c3e3c00a6782e1b393c99188ba5/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/f3e7f78fcbb15c3e3c00a6782e1b393c99188ba5/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f3e7f78fcbb15c3e3c00a6782e1b393c99188ba5/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f3e7f78fcbb15c3e3c00a6782e1b393c99188ba5/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f3e7f78fcbb15c3e3c00a6782e1b393c99188ba5/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f3e7f78fcbb15c3e3c00a6782e1b393c99188ba5/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f3e7f78fcbb15c3e3c00a6782e1b393c99188ba5/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f3e7f78fcbb15c3e3c00a6782e1b393c99188ba5/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4826,6 +4843,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5839,11 +5857,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/f3e7f78fcbb15c3e3c00a6782e1b393c99188ba5/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/f3e7f78fcbb15c3e3c00a6782e1b393c99188ba5/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5866,7 +5884,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/f3e7f78fcbb15c3e3c00a6782e1b393c99188ba5/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 336)
     return getfield(x, f)
 end

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/01b2d93e5c4155c6afe84946168da2ac5166a6ae/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/9e2aa2bda16ce11e00f71596ecc0f92ae599a167/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/9e2aa2bda16ce11e00f71596ecc0f92ae599a167/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e2aa2bda16ce11e00f71596ecc0f92ae599a167/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9e2aa2bda16ce11e00f71596ecc0f92ae599a167/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9e2aa2bda16ce11e00f71596ecc0f92ae599a167/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e2aa2bda16ce11e00f71596ecc0f92ae599a167/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e2aa2bda16ce11e00f71596ecc0f92ae599a167/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e2aa2bda16ce11e00f71596ecc0f92ae599a167/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4826,6 +4843,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5835,11 +5853,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/9e2aa2bda16ce11e00f71596ecc0f92ae599a167/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/9e2aa2bda16ce11e00f71596ecc0f92ae599a167/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5862,7 +5880,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/9e2aa2bda16ce11e00f71596ecc0f92ae599a167/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 320)
     return getfield(x, f)
 end

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/067ce97ac7e8c1aa098d8b6f7f6075e730c6f5ab/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/b16c138a239c06ce3f5d19c88b2cc44e0e818493/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/b16c138a239c06ce3f5d19c88b2cc44e0e818493/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b16c138a239c06ce3f5d19c88b2cc44e0e818493/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b16c138a239c06ce3f5d19c88b2cc44e0e818493/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b16c138a239c06ce3f5d19c88b2cc44e0e818493/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b16c138a239c06ce3f5d19c88b2cc44e0e818493/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b16c138a239c06ce3f5d19c88b2cc44e0e818493/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b16c138a239c06ce3f5d19c88b2cc44e0e818493/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1555,6 +1555,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1612,6 +1613,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4880,6 +4897,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5889,11 +5907,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/b16c138a239c06ce3f5d19c88b2cc44e0e818493/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/b16c138a239c06ce3f5d19c88b2cc44e0e818493/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5916,7 +5934,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/b16c138a239c06ce3f5d19c88b2cc44e0e818493/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/020d2c4fb5105f30cefec4129b0bd4c49a9e6f45/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/dd74fc29e57fcc0229e9acbb2b843bcde05de531/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/dd74fc29e57fcc0229e9acbb2b843bcde05de531/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dd74fc29e57fcc0229e9acbb2b843bcde05de531/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/dd74fc29e57fcc0229e9acbb2b843bcde05de531/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/dd74fc29e57fcc0229e9acbb2b843bcde05de531/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dd74fc29e57fcc0229e9acbb2b843bcde05de531/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dd74fc29e57fcc0229e9acbb2b843bcde05de531/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/dd74fc29e57fcc0229e9acbb2b843bcde05de531/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4826,6 +4843,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5835,11 +5853,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/dd74fc29e57fcc0229e9acbb2b843bcde05de531/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/dd74fc29e57fcc0229e9acbb2b843bcde05de531/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5862,7 +5880,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 32)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 88)
     f === :thread && return Ptr{aws_thread}(x + 92)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/dd74fc29e57fcc0229e9acbb2b843bcde05de531/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 208)
     return getfield(x, f)
 end

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2668429b906ded4385b08f8a7fb9a0c13b05ebcc/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/f49dd7e4480022bc342fe7b7b5d886601252cb92/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/f49dd7e4480022bc342fe7b7b5d886601252cb92/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f49dd7e4480022bc342fe7b7b5d886601252cb92/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f49dd7e4480022bc342fe7b7b5d886601252cb92/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f49dd7e4480022bc342fe7b7b5d886601252cb92/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f49dd7e4480022bc342fe7b7b5d886601252cb92/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f49dd7e4480022bc342fe7b7b5d886601252cb92/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f49dd7e4480022bc342fe7b7b5d886601252cb92/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -1555,6 +1555,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1612,6 +1613,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4880,6 +4897,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5889,11 +5907,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/f49dd7e4480022bc342fe7b7b5d886601252cb92/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/f49dd7e4480022bc342fe7b7b5d886601252cb92/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5916,7 +5934,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 32)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 88)
     f === :thread && return Ptr{aws_thread}(x + 92)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/f49dd7e4480022bc342fe7b7b5d886601252cb92/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 196)
     return getfield(x, f)
 end

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9e8351d266339d7323545b4f0e37b461021013a2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/302f4804fbd64b007586df83c6773af6403231df/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/302f4804fbd64b007586df83c6773af6403231df/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/302f4804fbd64b007586df83c6773af6403231df/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/302f4804fbd64b007586df83c6773af6403231df/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/302f4804fbd64b007586df83c6773af6403231df/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/302f4804fbd64b007586df83c6773af6403231df/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/302f4804fbd64b007586df83c6773af6403231df/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/302f4804fbd64b007586df83c6773af6403231df/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4826,6 +4843,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5835,11 +5853,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/302f4804fbd64b007586df83c6773af6403231df/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/302f4804fbd64b007586df83c6773af6403231df/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5862,7 +5880,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 28)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 80)
     f === :thread && return Ptr{aws_thread}(x + 84)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/302f4804fbd64b007586df83c6773af6403231df/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 188)
     return getfield(x, f)
 end

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/28fcbbecc8d063c78d39ef555253c3b98b8c62e1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/5d6a29c180a3139de43ee308d8d660b0cea7e7e1/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/5d6a29c180a3139de43ee308d8d660b0cea7e7e1/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5d6a29c180a3139de43ee308d8d660b0cea7e7e1/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5d6a29c180a3139de43ee308d8d660b0cea7e7e1/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5d6a29c180a3139de43ee308d8d660b0cea7e7e1/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5d6a29c180a3139de43ee308d8d660b0cea7e7e1/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5d6a29c180a3139de43ee308d8d660b0cea7e7e1/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5d6a29c180a3139de43ee308d8d660b0cea7e7e1/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -1555,6 +1555,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1612,6 +1613,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4880,6 +4897,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5889,11 +5907,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/5d6a29c180a3139de43ee308d8d660b0cea7e7e1/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/5d6a29c180a3139de43ee308d8d660b0cea7e7e1/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5916,7 +5934,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 28)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 80)
     f === :thread && return Ptr{aws_thread}(x + 84)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/5d6a29c180a3139de43ee308d8d660b0cea7e7e1/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 188)
     return getfield(x, f)
 end

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/3ecabe2ecdc49586ab68adb3d35cc3ca351a8825/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/688de5e94acc675bc280f579dda88d73c09d16ac/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/688de5e94acc675bc280f579dda88d73c09d16ac/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/688de5e94acc675bc280f579dda88d73c09d16ac/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/688de5e94acc675bc280f579dda88d73c09d16ac/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/688de5e94acc675bc280f579dda88d73c09d16ac/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/688de5e94acc675bc280f579dda88d73c09d16ac/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/688de5e94acc675bc280f579dda88d73c09d16ac/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/688de5e94acc675bc280f579dda88d73c09d16ac/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4826,6 +4843,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5835,11 +5853,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/688de5e94acc675bc280f579dda88d73c09d16ac/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/688de5e94acc675bc280f579dda88d73c09d16ac/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5862,7 +5880,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/688de5e94acc675bc280f579dda88d73c09d16ac/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81c525c57870bc80591eed7434615005a1544642/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/5a9297a3fde8a21829cb5225e38516aaf32d81d1/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/5a9297a3fde8a21829cb5225e38516aaf32d81d1/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5a9297a3fde8a21829cb5225e38516aaf32d81d1/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5a9297a3fde8a21829cb5225e38516aaf32d81d1/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5a9297a3fde8a21829cb5225e38516aaf32d81d1/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5a9297a3fde8a21829cb5225e38516aaf32d81d1/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5a9297a3fde8a21829cb5225e38516aaf32d81d1/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5a9297a3fde8a21829cb5225e38516aaf32d81d1/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4826,6 +4843,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5839,11 +5857,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/5a9297a3fde8a21829cb5225e38516aaf32d81d1/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/5a9297a3fde8a21829cb5225e38516aaf32d81d1/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5866,7 +5884,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/5a9297a3fde8a21829cb5225e38516aaf32d81d1/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 336)
     return getfield(x, f)
 end

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1285,28 +1285,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/67620c61f9a00a79634e24a9cdac1bfcf8a3b50a/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/67620c61f9a00a79634e24a9cdac1bfcf8a3b50a/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/67620c61f9a00a79634e24a9cdac1bfcf8a3b50a/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/67620c61f9a00a79634e24a9cdac1bfcf8a3b50a/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/67620c61f9a00a79634e24a9cdac1bfcf8a3b50a/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/67620c61f9a00a79634e24a9cdac1bfcf8a3b50a/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/67620c61f9a00a79634e24a9cdac1bfcf8a3b50a/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1326,7 +1326,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/67620c61f9a00a79634e24a9cdac1bfcf8a3b50a/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1475,6 +1475,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1532,6 +1533,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4800,6 +4817,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5809,11 +5827,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/67620c61f9a00a79634e24a9cdac1bfcf8a3b50a/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/67620c61f9a00a79634e24a9cdac1bfcf8a3b50a/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5836,7 +5854,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/67620c61f9a00a79634e24a9cdac1bfcf8a3b50a/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c28be5d35eed3f28c0bc09e61c01f53ee059f128/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1365,28 +1365,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/425022ebc8fa7767dc3ad68fe15065ed209341eb/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/425022ebc8fa7767dc3ad68fe15065ed209341eb/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/425022ebc8fa7767dc3ad68fe15065ed209341eb/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/425022ebc8fa7767dc3ad68fe15065ed209341eb/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/425022ebc8fa7767dc3ad68fe15065ed209341eb/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/425022ebc8fa7767dc3ad68fe15065ed209341eb/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/425022ebc8fa7767dc3ad68fe15065ed209341eb/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1406,7 +1406,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/425022ebc8fa7767dc3ad68fe15065ed209341eb/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1555,6 +1555,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1612,6 +1613,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4880,6 +4897,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5889,11 +5907,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/425022ebc8fa7767dc3ad68fe15065ed209341eb/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/425022ebc8fa7767dc3ad68fe15065ed209341eb/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5916,7 +5934,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/425022ebc8fa7767dc3ad68fe15065ed209341eb/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/81bc81e5cf25ff57cad1380978b60324ffff98b1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/1c71313ab01b4b5609bd0867fa817adbb5e08da2/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/1c71313ab01b4b5609bd0867fa817adbb5e08da2/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1c71313ab01b4b5609bd0867fa817adbb5e08da2/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1c71313ab01b4b5609bd0867fa817adbb5e08da2/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1c71313ab01b4b5609bd0867fa817adbb5e08da2/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1c71313ab01b4b5609bd0867fa817adbb5e08da2/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1c71313ab01b4b5609bd0867fa817adbb5e08da2/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1c71313ab01b4b5609bd0867fa817adbb5e08da2/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4826,6 +4843,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5835,11 +5853,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/1c71313ab01b4b5609bd0867fa817adbb5e08da2/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/1c71313ab01b4b5609bd0867fa817adbb5e08da2/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5862,7 +5880,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/1c71313ab01b4b5609bd0867fa817adbb5e08da2/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 240)
     return getfield(x, f)
 end

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)
+    union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b6ff8417c439f8083f62fa0e9278144b169a6520/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1311,28 +1311,28 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/6b13d89b06ed818de92670c51aebde19737d6205/include/aws/io/io.h:21:5)
+    union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/6b13d89b06ed818de92670c51aebde19737d6205/include/aws/io/io.h:21:5)"
+struct var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6b13d89b06ed818de92670c51aebde19737d6205/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)"}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6b13d89b06ed818de92670c51aebde19737d6205/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6b13d89b06ed818de92670c51aebde19737d6205/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6b13d89b06ed818de92670c51aebde19737d6205/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6b13d89b06ed818de92670c51aebde19737d6205/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -1352,7 +1352,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6b13d89b06ed818de92670c51aebde19737d6205/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)"}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1501,6 +1501,7 @@ struct aws_event_loop_vtable
     stop::Ptr{Cvoid}
     wait_for_stop_completion::Ptr{Cvoid}
     schedule_task_now::Ptr{Cvoid}
+    schedule_task_now_serialized::Ptr{Cvoid}
     schedule_task_future::Ptr{Cvoid}
     cancel_task::Ptr{Cvoid}
     connect_to_io_completion_port::Ptr{Cvoid}
@@ -1558,6 +1559,22 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
 """
 function aws_event_loop_schedule_task_now(event_loop, task)
     ccall((:aws_event_loop_schedule_task_now, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
+end
+
+"""
+    aws_event_loop_schedule_task_now_serialized(event_loop, task)
+
+Variant of [`aws_event_loop_schedule_task_now`](@ref) that forces all tasks to go through the cross thread task queue, guaranteeing that order-of-submission is order-of-execution. If you need this guarantee, you must use this function; the base function contains short-circuiting logic that breaks ordering invariants. Beyond that, all properties of [`aws_event_loop_schedule_task_now`](@ref) apply to this function as well.
+
+Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in certain cases).
+
+### Prototype
+```c
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
+```
+"""
+function aws_event_loop_schedule_task_now_serialized(event_loop, task)
+    ccall((:aws_event_loop_schedule_task_now_serialized, libaws_c_io), Cvoid, (Ptr{aws_event_loop}, Ptr{aws_task}), event_loop, task)
 end
 
 """
@@ -4840,6 +4857,7 @@ Documentation not found.
     AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10 = 7
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8
     AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06 = 10
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 65535
 end
 
@@ -5850,11 +5868,11 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/6b13d89b06ed818de92670c51aebde19737d6205/include/aws/testing/async_stream_tester.h:55:5)"
+    var"struct (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/testing/async_stream_tester.h:55:5)"
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/6b13d89b06ed818de92670c51aebde19737d6205/include/aws/testing/async_stream_tester.h:55:5)"
+struct var"struct (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/testing/async_stream_tester.h:55:5)"
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
@@ -5877,7 +5895,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6b13d89b06ed818de92670c51aebde19737d6205/include/aws/testing/async_stream_tester.h:55:5)"}(x + 192)
+    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/testing/async_stream_tester.h:55:5)"}(x + 192)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 248)
     return getfield(x, f)
 end


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_io_jll** to version **0.23.2**
- Updated **JuliaServices/LibAwsIO.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings