### PR TITLE
Update aws_c_io_jll to version 0.23.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsIO"
 uuid = "a5388770-19df-4151-b103-3d71de896ddf"
-version = "1.2.10"
+version = "1.2.11"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -13,7 +13,7 @@ Aqua = "0.7,0.8"
 CEnum = "0.5"
 LibAwsCal = "1.1.5"
 LibAwsCommon = "1.2.4"
-aws_c_io_jll = "=0.23.2"
+aws_c_io_jll = "=0.23.3"
 julia = "1.6"
 Test = "1.9"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -10,4 +10,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3,0.19"
 JLLPrefixes = "0.3,0.4"
-aws_c_io_jll = "=0.23.2"
+aws_c_io_jll = "=0.23.3"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1,29 +1,37 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)
+    __JL_Ctag_59
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"
+struct __JL_Ctag_59
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_59}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_59, f::Symbol)
+    r = Ref{__JL_Ctag_59}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_59}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/458f6fa7396dedb92029fe05626904baeedf7254/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_59}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_59, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -91,7 +99,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -243,6 +251,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1311,29 +1327,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)
+    __JL_Ctag_60
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_60
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_60}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_60, f::Symbol)
+    r = Ref{__JL_Ctag_60}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_60}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_60}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_60, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1352,7 +1376,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_60}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1367,6 +1391,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1436,6 +1468,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1735,6 +1775,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2174,14 +2228,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2194,7 +2249,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2207,7 +2263,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2220,7 +2277,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2233,7 +2291,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2246,7 +2305,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2259,7 +2319,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2272,7 +2333,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2285,7 +2347,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2298,7 +2361,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2311,7 +2375,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2324,7 +2389,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2337,7 +2403,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2350,7 +2417,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2363,7 +2431,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2376,7 +2445,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2389,7 +2459,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2402,7 +2473,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2415,7 +2487,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2428,7 +2501,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2441,7 +2515,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2454,7 +2529,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2467,7 +2543,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2480,7 +2557,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2493,7 +2571,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2506,7 +2585,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2517,7 +2597,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5857,17 +5937,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_61
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_61
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_61}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 72)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 128)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 136)
+    f === :do_shutdown && return Ptr{Bool}(x + 144)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_61, f::Symbol)
+    r = Ref{__JL_Ctag_61}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_61}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_61}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5884,7 +5984,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/83b7f043dab4a23b0e22d7bbb9146013658b4cd1/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{__JL_Ctag_61}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 336)
     return getfield(x, f)
 end
@@ -5898,6 +5998,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1,29 +1,37 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)
+    __JL_Ctag_244
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"
+struct __JL_Ctag_244
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_244}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_244, f::Symbol)
+    r = Ref{__JL_Ctag_244}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_244}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8cbe1f93d5c6e7a9916e1ea7bed856d4f9d110bb/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_244}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_244, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -91,7 +99,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -243,6 +251,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1311,29 +1327,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)
+    __JL_Ctag_245
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_245
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_245}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_245, f::Symbol)
+    r = Ref{__JL_Ctag_245}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_245}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_245}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_245, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1352,7 +1376,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_245}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1367,6 +1391,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1436,6 +1468,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1735,6 +1775,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2174,14 +2228,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2194,7 +2249,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2207,7 +2263,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2220,7 +2277,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2233,7 +2291,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2246,7 +2305,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2259,7 +2319,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2272,7 +2333,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2285,7 +2347,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2298,7 +2361,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2311,7 +2375,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2324,7 +2389,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2337,7 +2403,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2350,7 +2417,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2363,7 +2431,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2376,7 +2445,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2389,7 +2459,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2402,7 +2473,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2415,7 +2487,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2428,7 +2501,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2441,7 +2515,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2454,7 +2529,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2467,7 +2543,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2480,7 +2557,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2493,7 +2571,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2506,7 +2585,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2517,7 +2597,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5853,17 +5933,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_246
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_246
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_246}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 56)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 112)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 120)
+    f === :do_shutdown && return Ptr{Bool}(x + 128)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_246, f::Symbol)
+    r = Ref{__JL_Ctag_246}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_246}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_246}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5880,7 +5980,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/138b3a3c9b428723c35890b964220a8359401fb8/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{__JL_Ctag_246}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 320)
     return getfield(x, f)
 end
@@ -5894,6 +5994,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -6891,11 +6999,11 @@ function aws_input_stream_new_tester(alloc, options)
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/5db9b46496bfd3b55724b246c46f9fe838cc66ca/aarch64-linux-gnu/sys-root/usr/include/bits/pthreadtypes.h:88:3)"
+    __JL_Ctag_243
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/5db9b46496bfd3b55724b246c46f9fe838cc66ca/aarch64-linux-gnu/sys-root/usr/include/bits/pthreadtypes.h:88:3)"
+struct __JL_Ctag_243
     __lock::Cint
     __futex::Cuint
     __total_seq::Culonglong
@@ -6905,6 +7013,29 @@ struct var"struct (unnamed at /home/runner/.julia/artifacts/5db9b46496bfd3b55724
     __nwaiters::Cuint
     __broadcast_seq::Cuint
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_243}, f::Symbol)
+    f === :__lock && return Ptr{Cint}(x + 0)
+    f === :__futex && return Ptr{Cuint}(x + 4)
+    f === :__total_seq && return Ptr{Culonglong}(x + 8)
+    f === :__wakeup_seq && return Ptr{Culonglong}(x + 16)
+    f === :__woken_seq && return Ptr{Culonglong}(x + 24)
+    f === :__mutex && return Ptr{Ptr{Cvoid}}(x + 32)
+    f === :__nwaiters && return Ptr{Cuint}(x + 40)
+    f === :__broadcast_seq && return Ptr{Cuint}(x + 44)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_243, f::Symbol)
+    r = Ref{__JL_Ctag_243}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_243}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_243}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
 Documentation not found.

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1,83 +1,107 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)
+    __JL_Ctag_58
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"
+struct __JL_Ctag_58
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_58}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_58, f::Symbol)
+    r = Ref{__JL_Ctag_58}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_58}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/becd48d1b5d0b2e947154f190c0f7a2950c90223/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_58}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+function Base.propertynames(x::__JL_Ctag_58, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
+
 """
-    union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:74:18)
+    __JL_Ctag_56
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:74:18)"
+struct __JL_Ctag_56
     data::NTuple{40, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:74:18)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_56}, f::Symbol)
     f === :__i && return Ptr{NTuple{10, Cint}}(x + 0)
     f === :__vi && return Ptr{NTuple{10, Cint}}(x + 0)
     f === :__p && return Ptr{NTuple{5, Ptr{Cvoid}}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:74:18)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:74:18)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:74:18)"}, r)
+function Base.getproperty(x::__JL_Ctag_56, f::Symbol)
+    r = Ref{__JL_Ctag_56}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_56}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:74:18)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_56}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+function Base.propertynames(x::__JL_Ctag_56, private::Bool = false)
+    (:__i, :__vi, :__p, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
+
 """
-    union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:84:18)
+    __JL_Ctag_57
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:84:18)"
+struct __JL_Ctag_57
     data::NTuple{48, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:84:18)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_57}, f::Symbol)
     f === :__i && return Ptr{NTuple{12, Cint}}(x + 0)
     f === :__vi && return Ptr{NTuple{12, Cint}}(x + 0)
     f === :__p && return Ptr{NTuple{6, Ptr{Cvoid}}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:84:18)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:84:18)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:84:18)"}, r)
+function Base.getproperty(x::__JL_Ctag_57, f::Symbol)
+    r = Ref{__JL_Ctag_57}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_57}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b5044bc28bf79908f7c0ffc29230b7cc56e3c1f5/aarch64-linux-musl/sys-root/usr/include/bits/alltypes.h:84:18)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_57}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_57, private::Bool = false)
+    (:__i, :__vi, :__p, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -145,7 +169,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -297,6 +321,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1365,29 +1397,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)
+    __JL_Ctag_59
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_59
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_59}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_59, f::Symbol)
+    r = Ref{__JL_Ctag_59}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_59}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_59}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_59, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1406,7 +1446,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_59}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1421,6 +1461,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1490,6 +1538,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1789,6 +1845,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2228,14 +2298,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2248,7 +2319,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2261,7 +2333,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2274,7 +2347,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2287,7 +2361,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2300,7 +2375,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2313,7 +2389,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2326,7 +2403,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2339,7 +2417,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2352,7 +2431,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2365,7 +2445,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2378,7 +2459,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2391,7 +2473,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2404,7 +2487,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2417,7 +2501,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2430,7 +2515,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2443,7 +2529,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2456,7 +2543,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2469,7 +2557,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2482,7 +2571,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2495,7 +2585,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2508,7 +2599,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2521,7 +2613,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2534,7 +2627,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2547,7 +2641,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2560,7 +2655,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2571,7 +2667,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5907,17 +6003,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_60
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_60
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_60}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 48)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 104)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 112)
+    f === :do_shutdown && return Ptr{Bool}(x + 120)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_60, f::Symbol)
+    r = Ref{__JL_Ctag_60}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_60}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_60}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5934,7 +6050,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/cd7699a5cea537de7f88d40c930eb9b2261279e5/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{__JL_Ctag_60}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end
@@ -5948,6 +6064,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1,29 +1,37 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)
+    __JL_Ctag_245
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"
+struct __JL_Ctag_245
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_245}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_245, f::Symbol)
+    r = Ref{__JL_Ctag_245}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_245}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7619ce74ecdaafe369da884872f1eec8ebc9feb0/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_245}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_245, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -91,7 +99,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -243,6 +251,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1311,29 +1327,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)
+    __JL_Ctag_246
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_246
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_246}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_246, f::Symbol)
+    r = Ref{__JL_Ctag_246}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_246}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_246}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_246, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1352,7 +1376,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_246}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -1367,6 +1391,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1436,6 +1468,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1735,6 +1775,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2174,14 +2228,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2194,7 +2249,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2207,7 +2263,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2220,7 +2277,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2233,7 +2291,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2246,7 +2305,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2259,7 +2319,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2272,7 +2333,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2285,7 +2347,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2298,7 +2361,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2311,7 +2375,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2324,7 +2389,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2337,7 +2403,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2350,7 +2417,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2363,7 +2431,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2376,7 +2445,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2389,7 +2459,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2402,7 +2473,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2415,7 +2487,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2428,7 +2501,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2441,7 +2515,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2454,7 +2529,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2467,7 +2543,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2480,7 +2557,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2493,7 +2571,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2506,7 +2585,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2517,7 +2597,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5853,17 +5933,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_247
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_247
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_247}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 32)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 88)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 92)
+    f === :do_shutdown && return Ptr{Bool}(x + 96)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_247, f::Symbol)
+    r = Ref{__JL_Ctag_247}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_247}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_247}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5880,7 +5980,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 32)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 88)
     f === :thread && return Ptr{aws_thread}(x + 92)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/e39748bc34a34bade348220cc12ad3624d7e5068/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
+    f === :synced_data && return Ptr{__JL_Ctag_247}(x + 104)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 208)
     return getfield(x, f)
 end
@@ -5894,6 +5994,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -6891,11 +6999,11 @@ function aws_input_stream_new_tester(alloc, options)
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/8829cc041d600db0e8623c301d4ae8906fa1f060/arm-linux-gnueabihf/sys-root/usr/include/bits/pthreadtypes.h:91:3)"
+    __JL_Ctag_244
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/8829cc041d600db0e8623c301d4ae8906fa1f060/arm-linux-gnueabihf/sys-root/usr/include/bits/pthreadtypes.h:91:3)"
+struct __JL_Ctag_244
     __lock::Cint
     __futex::Cuint
     __total_seq::Culonglong
@@ -6905,6 +7013,29 @@ struct var"struct (unnamed at /home/runner/.julia/artifacts/8829cc041d600db0e862
     __nwaiters::Cuint
     __broadcast_seq::Cuint
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_244}, f::Symbol)
+    f === :__lock && return Ptr{Cint}(x + 0)
+    f === :__futex && return Ptr{Cuint}(x + 4)
+    f === :__total_seq && return Ptr{Culonglong}(x + 8)
+    f === :__wakeup_seq && return Ptr{Culonglong}(x + 16)
+    f === :__woken_seq && return Ptr{Culonglong}(x + 24)
+    f === :__mutex && return Ptr{Ptr{Cvoid}}(x + 32)
+    f === :__nwaiters && return Ptr{Cuint}(x + 36)
+    f === :__broadcast_seq && return Ptr{Cuint}(x + 40)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_244, f::Symbol)
+    r = Ref{__JL_Ctag_244}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_244}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_244}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
 Documentation not found.

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1,83 +1,107 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)
+    __JL_Ctag_58
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"
+struct __JL_Ctag_58
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_58}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_58, f::Symbol)
+    r = Ref{__JL_Ctag_58}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_58}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e7f81f17200b82e6fd9460b1d65c223719604cc1/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_58}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+function Base.propertynames(x::__JL_Ctag_58, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
+
 """
-    union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:58:18)
+    __JL_Ctag_56
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:58:18)"
+struct __JL_Ctag_56
     data::NTuple{24, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:58:18)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_56}, f::Symbol)
     f === :__i && return Ptr{NTuple{6, Cint}}(x + 0)
     f === :__vi && return Ptr{NTuple{6, Cint}}(x + 0)
     f === :__p && return Ptr{NTuple{6, Ptr{Cvoid}}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:58:18)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:58:18)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:58:18)"}, r)
+function Base.getproperty(x::__JL_Ctag_56, f::Symbol)
+    r = Ref{__JL_Ctag_56}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_56}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:58:18)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_56}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+function Base.propertynames(x::__JL_Ctag_56, private::Bool = false)
+    (:__i, :__vi, :__p, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
+
 """
-    union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:68:18)
+    __JL_Ctag_57
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:68:18)"
+struct __JL_Ctag_57
     data::NTuple{48, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:68:18)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_57}, f::Symbol)
     f === :__i && return Ptr{NTuple{12, Cint}}(x + 0)
     f === :__vi && return Ptr{NTuple{12, Cint}}(x + 0)
     f === :__p && return Ptr{NTuple{12, Ptr{Cvoid}}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:68:18)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:68:18)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:68:18)"}, r)
+function Base.getproperty(x::__JL_Ctag_57, f::Symbol)
+    r = Ref{__JL_Ctag_57}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_57}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/452cde0499419e984225c72bc1d2c37ee97a2259/arm-linux-musleabihf/sys-root/usr/include/bits/alltypes.h:68:18)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_57}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_57, private::Bool = false)
+    (:__i, :__vi, :__p, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -145,7 +169,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -297,6 +321,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1365,29 +1397,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)
+    __JL_Ctag_59
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_59
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_59}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_59, f::Symbol)
+    r = Ref{__JL_Ctag_59}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_59}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_59}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_59, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1406,7 +1446,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_59}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -1421,6 +1461,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1490,6 +1538,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1789,6 +1845,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2228,14 +2298,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2248,7 +2319,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2261,7 +2333,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2274,7 +2347,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2287,7 +2361,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2300,7 +2375,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2313,7 +2389,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2326,7 +2403,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2339,7 +2417,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2352,7 +2431,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2365,7 +2445,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2378,7 +2459,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2391,7 +2473,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2404,7 +2487,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2417,7 +2501,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2430,7 +2515,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2443,7 +2529,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2456,7 +2543,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2469,7 +2557,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2482,7 +2571,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2495,7 +2585,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2508,7 +2599,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2521,7 +2613,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2534,7 +2627,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2547,7 +2641,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2560,7 +2655,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2571,7 +2667,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5907,17 +6003,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_60
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_60
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_60}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 28)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 80)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 84)
+    f === :do_shutdown && return Ptr{Bool}(x + 88)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_60, f::Symbol)
+    r = Ref{__JL_Ctag_60}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_60}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_60}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5934,7 +6050,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 32)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 88)
     f === :thread && return Ptr{aws_thread}(x + 92)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/fec90bd565d6ee1c4597b9ec4515f1a471c9fa3c/include/aws/testing/async_stream_tester.h:55:5)"}(x + 104)
+    f === :synced_data && return Ptr{__JL_Ctag_60}(x + 104)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 196)
     return getfield(x, f)
 end
@@ -5948,6 +6064,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1,29 +1,37 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)
+    __JL_Ctag_220
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"
+struct __JL_Ctag_220
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_220}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_220, f::Symbol)
+    r = Ref{__JL_Ctag_220}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_220}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/643c90580b967dc5141917845b1c1685e3f5b8ac/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_220}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_220, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -91,7 +99,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -243,6 +251,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1311,29 +1327,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)
+    __JL_Ctag_221
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_221
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_221}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_221, f::Symbol)
+    r = Ref{__JL_Ctag_221}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_221}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_221}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_221, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1352,7 +1376,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_221}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -1367,6 +1391,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1436,6 +1468,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1735,6 +1775,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2174,14 +2228,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2194,7 +2249,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2207,7 +2263,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2220,7 +2277,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2233,7 +2291,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2246,7 +2305,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2259,7 +2319,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2272,7 +2333,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2285,7 +2347,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2298,7 +2361,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2311,7 +2375,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2324,7 +2389,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2337,7 +2403,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2350,7 +2417,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2363,7 +2431,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2376,7 +2445,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2389,7 +2459,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2402,7 +2473,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2415,7 +2487,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2428,7 +2501,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2441,7 +2515,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2454,7 +2529,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2467,7 +2543,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2480,7 +2557,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2493,7 +2571,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2506,7 +2585,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2517,7 +2597,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5853,17 +5933,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_222
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_222
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_222}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 28)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 80)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 84)
+    f === :do_shutdown && return Ptr{Bool}(x + 88)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_222, f::Symbol)
+    r = Ref{__JL_Ctag_222}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_222}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_222}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5880,7 +5980,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 28)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 80)
     f === :thread && return Ptr{aws_thread}(x + 84)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/57b649b1ef28c07f32506b8ae4137f8d248119fe/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
+    f === :synced_data && return Ptr{__JL_Ctag_222}(x + 96)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 188)
     return getfield(x, f)
 end
@@ -5894,6 +5994,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -6891,11 +6999,11 @@ function aws_input_stream_new_tester(alloc, options)
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/908fff64d0a2dbb4530441fdef29c848a311285a/i686-linux-gnu/sys-root/usr/include/bits/pthreadtypes.h:131:3)"
+    __JL_Ctag_219
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/908fff64d0a2dbb4530441fdef29c848a311285a/i686-linux-gnu/sys-root/usr/include/bits/pthreadtypes.h:131:3)"
+struct __JL_Ctag_219
     __lock::Cint
     __futex::Cuint
     __total_seq::Culonglong
@@ -6905,6 +7013,29 @@ struct var"struct (unnamed at /home/runner/.julia/artifacts/908fff64d0a2dbb45304
     __nwaiters::Cuint
     __broadcast_seq::Cuint
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_219}, f::Symbol)
+    f === :__lock && return Ptr{Cint}(x + 0)
+    f === :__futex && return Ptr{Cuint}(x + 4)
+    f === :__total_seq && return Ptr{Culonglong}(x + 8)
+    f === :__wakeup_seq && return Ptr{Culonglong}(x + 16)
+    f === :__woken_seq && return Ptr{Culonglong}(x + 24)
+    f === :__mutex && return Ptr{Ptr{Cvoid}}(x + 32)
+    f === :__nwaiters && return Ptr{Cuint}(x + 36)
+    f === :__broadcast_seq && return Ptr{Cuint}(x + 40)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_219, f::Symbol)
+    r = Ref{__JL_Ctag_219}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_219}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_219}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
 Documentation not found.

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1,83 +1,107 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)
+    __JL_Ctag_58
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"
+struct __JL_Ctag_58
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_58}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_58, f::Symbol)
+    r = Ref{__JL_Ctag_58}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_58}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1dca5ae95f5d9dc2ecc6cba4d75517a904aea022/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_58}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+function Base.propertynames(x::__JL_Ctag_58, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
+
 """
-    union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:106:18)
+    __JL_Ctag_56
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:106:18)"
+struct __JL_Ctag_56
     data::NTuple{24, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:106:18)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_56}, f::Symbol)
     f === :__i && return Ptr{NTuple{6, Cint}}(x + 0)
     f === :__vi && return Ptr{NTuple{6, Cint}}(x + 0)
     f === :__p && return Ptr{NTuple{6, Ptr{Cvoid}}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:106:18)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:106:18)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:106:18)"}, r)
+function Base.getproperty(x::__JL_Ctag_56, f::Symbol)
+    r = Ref{__JL_Ctag_56}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_56}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:106:18)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_56}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+function Base.propertynames(x::__JL_Ctag_56, private::Bool = false)
+    (:__i, :__vi, :__p, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
+
 """
-    union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:116:18)
+    __JL_Ctag_57
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:116:18)"
+struct __JL_Ctag_57
     data::NTuple{48, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:116:18)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_57}, f::Symbol)
     f === :__i && return Ptr{NTuple{12, Cint}}(x + 0)
     f === :__vi && return Ptr{NTuple{12, Cint}}(x + 0)
     f === :__p && return Ptr{NTuple{12, Ptr{Cvoid}}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:116:18)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:116:18)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:116:18)"}, r)
+function Base.getproperty(x::__JL_Ctag_57, f::Symbol)
+    r = Ref{__JL_Ctag_57}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_57}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c1485bc6db225419eab1c75fd2e9ebec502a6a27/i686-linux-musl/sys-root/usr/include/bits/alltypes.h:116:18)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_57}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_57, private::Bool = false)
+    (:__i, :__vi, :__p, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -145,7 +169,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -297,6 +321,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1365,29 +1397,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)
+    __JL_Ctag_59
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_59
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_59}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_59, f::Symbol)
+    r = Ref{__JL_Ctag_59}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_59}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_59}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_59, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1406,7 +1446,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_59}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 4)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 8)
     return getfield(x, f)
@@ -1421,6 +1461,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1490,6 +1538,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1789,6 +1845,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2228,14 +2298,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2248,7 +2319,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2261,7 +2333,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2274,7 +2347,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2287,7 +2361,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2300,7 +2375,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2313,7 +2389,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2326,7 +2403,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2339,7 +2417,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2352,7 +2431,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2365,7 +2445,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2378,7 +2459,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2391,7 +2473,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2404,7 +2487,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2417,7 +2501,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2430,7 +2515,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2443,7 +2529,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2456,7 +2543,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2469,7 +2557,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2482,7 +2571,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2495,7 +2585,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2508,7 +2599,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2521,7 +2613,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2534,7 +2627,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2547,7 +2641,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2560,7 +2655,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2571,7 +2667,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5907,17 +6003,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_60
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_60
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_60}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 28)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 80)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 84)
+    f === :do_shutdown && return Ptr{Bool}(x + 88)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_60, f::Symbol)
+    r = Ref{__JL_Ctag_60}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_60}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_60}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5934,7 +6050,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 28)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 80)
     f === :thread && return Ptr{aws_thread}(x + 84)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/7d7a5e5e18d00f31c8685ea85dd13f1ce3cdaea0/include/aws/testing/async_stream_tester.h:55:5)"}(x + 96)
+    f === :synced_data && return Ptr{__JL_Ctag_60}(x + 96)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 188)
     return getfield(x, f)
 end
@@ -5948,6 +6064,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1,29 +1,37 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)
+    __JL_Ctag_220
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"
+struct __JL_Ctag_220
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_220}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_220, f::Symbol)
+    r = Ref{__JL_Ctag_220}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_220}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/a6e897c4b702a23552ab4d7638e661f90ebb55ad/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_220}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_220, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -91,7 +99,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -243,6 +251,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1311,29 +1327,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)
+    __JL_Ctag_221
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_221
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_221}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_221, f::Symbol)
+    r = Ref{__JL_Ctag_221}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_221}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_221}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_221, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1352,7 +1376,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_221}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1367,6 +1391,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1436,6 +1468,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1735,6 +1775,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2174,14 +2228,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2194,7 +2249,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2207,7 +2263,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2220,7 +2277,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2233,7 +2291,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2246,7 +2305,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2259,7 +2319,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2272,7 +2333,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2285,7 +2347,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2298,7 +2361,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2311,7 +2375,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2324,7 +2389,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2337,7 +2403,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2350,7 +2417,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2363,7 +2431,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2376,7 +2445,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2389,7 +2459,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2402,7 +2473,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2415,7 +2487,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2428,7 +2501,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2441,7 +2515,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2454,7 +2529,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2467,7 +2543,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2480,7 +2557,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2493,7 +2571,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2506,7 +2585,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2517,7 +2597,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5853,17 +5933,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_222
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_222
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_222}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 48)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 104)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 112)
+    f === :do_shutdown && return Ptr{Bool}(x + 120)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_222, f::Symbol)
+    r = Ref{__JL_Ctag_222}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_222}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_222}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5880,7 +5980,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/8ade83cca92b6c1b18fdafec52a49622beb8e70b/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{__JL_Ctag_222}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end
@@ -5894,6 +5994,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -6891,11 +6999,11 @@ function aws_input_stream_new_tester(alloc, options)
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/76c1b54e292ca0b742bbcd23509f6878cf1477a6/powerpc64le-linux-gnu/sys-root/usr/include/bits/pthreadtypes.h:120:3)"
+    __JL_Ctag_219
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/76c1b54e292ca0b742bbcd23509f6878cf1477a6/powerpc64le-linux-gnu/sys-root/usr/include/bits/pthreadtypes.h:120:3)"
+struct __JL_Ctag_219
     __lock::Cint
     __futex::Cuint
     __total_seq::Culonglong
@@ -6905,6 +7013,29 @@ struct var"struct (unnamed at /home/runner/.julia/artifacts/76c1b54e292ca0b742bb
     __nwaiters::Cuint
     __broadcast_seq::Cuint
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_219}, f::Symbol)
+    f === :__lock && return Ptr{Cint}(x + 0)
+    f === :__futex && return Ptr{Cuint}(x + 4)
+    f === :__total_seq && return Ptr{Culonglong}(x + 8)
+    f === :__wakeup_seq && return Ptr{Culonglong}(x + 16)
+    f === :__woken_seq && return Ptr{Culonglong}(x + 24)
+    f === :__mutex && return Ptr{Ptr{Cvoid}}(x + 32)
+    f === :__nwaiters && return Ptr{Cuint}(x + 40)
+    f === :__broadcast_seq && return Ptr{Cuint}(x + 44)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_219, f::Symbol)
+    r = Ref{__JL_Ctag_219}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_219}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_219}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
 Documentation not found.

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1,29 +1,37 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)
+    __JL_Ctag_59
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"
+struct __JL_Ctag_59
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_59}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_59, f::Symbol)
+    r = Ref{__JL_Ctag_59}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_59}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/2105f366bf12822c199816056a53b01efa8c62b2/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_59}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_59, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -91,7 +99,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -243,6 +251,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1311,29 +1327,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)
+    __JL_Ctag_60
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_60
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_60}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_60, f::Symbol)
+    r = Ref{__JL_Ctag_60}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_60}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_60}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_60, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1352,7 +1376,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_60}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1367,6 +1391,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1436,6 +1468,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1735,6 +1775,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2174,14 +2228,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2194,7 +2249,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2207,7 +2263,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2220,7 +2277,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2233,7 +2291,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2246,7 +2305,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2259,7 +2319,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2272,7 +2333,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2285,7 +2347,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2298,7 +2361,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2311,7 +2375,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2324,7 +2389,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2337,7 +2403,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2350,7 +2417,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2363,7 +2431,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2376,7 +2445,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2389,7 +2459,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2402,7 +2473,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2415,7 +2487,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2428,7 +2501,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2441,7 +2515,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2454,7 +2529,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2467,7 +2543,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2480,7 +2557,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2493,7 +2571,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2506,7 +2585,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2517,7 +2597,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5857,17 +5937,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_61
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_61
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_61}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 72)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 128)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 136)
+    f === :do_shutdown && return Ptr{Bool}(x + 144)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_61, f::Symbol)
+    r = Ref{__JL_Ctag_61}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_61}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_61}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5884,7 +5984,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/6a52eb13607e1edffb0ce1a97a035cd01d023159/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{__JL_Ctag_61}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 336)
     return getfield(x, f)
 end
@@ -5898,6 +5998,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1,4 +1,38 @@
-using CEnum
+using CEnum: CEnum, @cenum
+
+"""
+    __JL_Ctag_217
+
+Documentation not found.
+"""
+struct __JL_Ctag_217
+    data::NTuple{8, UInt8}
+end
+
+function Base.getproperty(x::Ptr{__JL_Ctag_217}, f::Symbol)
+    f === :scheduled && return Ptr{Bool}(x + 0)
+    f === :reserved && return Ptr{Csize_t}(x + 0)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_217, f::Symbol)
+    r = Ref{__JL_Ctag_217}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_217}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_217}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_217, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
 
 """
     aws_async_input_stream_vtable
@@ -65,7 +99,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -217,6 +251,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1285,29 +1327,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)
+    __JL_Ctag_218
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_218
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_218}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_218, f::Symbol)
+    r = Ref{__JL_Ctag_218}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_218}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_218}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_218, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1326,7 +1376,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_218}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1341,6 +1391,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1410,6 +1468,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1709,6 +1775,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2148,14 +2228,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2168,7 +2249,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2181,7 +2263,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2194,7 +2277,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2207,7 +2291,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2220,7 +2305,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2233,7 +2319,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2246,7 +2333,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2259,7 +2347,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2272,7 +2361,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2285,7 +2375,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2298,7 +2389,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2311,7 +2403,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2324,7 +2417,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2337,7 +2431,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2350,7 +2445,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2363,7 +2459,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2376,7 +2473,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2389,7 +2487,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2402,7 +2501,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2415,7 +2515,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2428,7 +2529,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2441,7 +2543,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2454,7 +2557,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2467,7 +2571,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2480,7 +2585,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2491,7 +2597,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5827,17 +5933,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_219
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_219
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_219}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 48)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 104)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 112)
+    f === :do_shutdown && return Ptr{Bool}(x + 120)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_219, f::Symbol)
+    r = Ref{__JL_Ctag_219}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_219}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_219}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5854,7 +5980,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/e6aa66d2a483434eb3b73f46d29285ab376004ff/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{__JL_Ctag_219}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end
@@ -5868,6 +5994,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -6863,6 +6997,45 @@ static inline struct aws_input_stream *aws_input_stream_new_tester( struct aws_a
 function aws_input_stream_new_tester(alloc, options)
     ccall((:aws_input_stream_new_tester, libaws_c_io), Ptr{aws_input_stream}, (Ptr{aws_allocator}, Ptr{aws_input_stream_tester_options}), alloc, options)
 end
+
+"""
+    __JL_Ctag_216
+
+Documentation not found.
+"""
+struct __JL_Ctag_216
+    __lock::Cint
+    __futex::Cuint
+    __total_seq::Culonglong
+    __wakeup_seq::Culonglong
+    __woken_seq::Culonglong
+    __mutex::Ptr{Cvoid}
+    __nwaiters::Cuint
+    __broadcast_seq::Cuint
+end
+function Base.getproperty(x::Ptr{__JL_Ctag_216}, f::Symbol)
+    f === :__lock && return Ptr{Cint}(x + 0)
+    f === :__futex && return Ptr{Cuint}(x + 4)
+    f === :__total_seq && return Ptr{Culonglong}(x + 8)
+    f === :__wakeup_seq && return Ptr{Culonglong}(x + 16)
+    f === :__woken_seq && return Ptr{Culonglong}(x + 24)
+    f === :__mutex && return Ptr{Ptr{Cvoid}}(x + 32)
+    f === :__nwaiters && return Ptr{Cuint}(x + 40)
+    f === :__broadcast_seq && return Ptr{Cuint}(x + 44)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_216, f::Symbol)
+    r = Ref{__JL_Ctag_216}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_216}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_216}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
 Documentation not found.

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1,83 +1,107 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)
+    __JL_Ctag_58
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"
+struct __JL_Ctag_58
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_58}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_58, f::Symbol)
+    r = Ref{__JL_Ctag_58}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_58}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c397ee551c97c2b9f3c22b3455775eab83f802f9/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_58}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+function Base.propertynames(x::__JL_Ctag_58, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
+
 """
-    union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:71:18)
+    __JL_Ctag_56
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:71:18)"
+struct __JL_Ctag_56
     data::NTuple{40, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:71:18)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_56}, f::Symbol)
     f === :__i && return Ptr{NTuple{10, Cint}}(x + 0)
     f === :__vi && return Ptr{NTuple{10, Cint}}(x + 0)
     f === :__p && return Ptr{NTuple{5, Ptr{Cvoid}}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:71:18)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:71:18)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:71:18)"}, r)
+function Base.getproperty(x::__JL_Ctag_56, f::Symbol)
+    r = Ref{__JL_Ctag_56}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_56}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:71:18)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_56}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+function Base.propertynames(x::__JL_Ctag_56, private::Bool = false)
+    (:__i, :__vi, :__p, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
+
 """
-    union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:81:18)
+    __JL_Ctag_57
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:81:18)"
+struct __JL_Ctag_57
     data::NTuple{48, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:81:18)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_57}, f::Symbol)
     f === :__i && return Ptr{NTuple{12, Cint}}(x + 0)
     f === :__vi && return Ptr{NTuple{12, Cint}}(x + 0)
     f === :__p && return Ptr{NTuple{6, Ptr{Cvoid}}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:81:18)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:81:18)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:81:18)"}, r)
+function Base.getproperty(x::__JL_Ctag_57, f::Symbol)
+    r = Ref{__JL_Ctag_57}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_57}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e5229ab63cfb1c1deb9c8f461889787e648eaeba/x86_64-linux-musl/sys-root/usr/include/bits/alltypes.h:81:18)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_57}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_57, private::Bool = false)
+    (:__i, :__vi, :__p, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -145,7 +169,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -297,6 +321,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1365,29 +1397,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)
+    __JL_Ctag_59
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_59
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_59}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_59, f::Symbol)
+    r = Ref{__JL_Ctag_59}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_59}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_59}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_59, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1406,7 +1446,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_59}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1421,6 +1461,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1490,6 +1538,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1789,6 +1845,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2228,14 +2298,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2248,7 +2319,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2261,7 +2333,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2274,7 +2347,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2287,7 +2361,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2300,7 +2375,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2313,7 +2389,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2326,7 +2403,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2339,7 +2417,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2352,7 +2431,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2365,7 +2445,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2378,7 +2459,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2391,7 +2473,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2404,7 +2487,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2417,7 +2501,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2430,7 +2515,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2443,7 +2529,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2456,7 +2543,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2469,7 +2557,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2482,7 +2571,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2495,7 +2585,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2508,7 +2599,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2521,7 +2613,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2534,7 +2627,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2547,7 +2641,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2560,7 +2655,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2571,7 +2667,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5907,17 +6003,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_60
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_60
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_60}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 48)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 104)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 112)
+    f === :do_shutdown && return Ptr{Bool}(x + 120)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_60, f::Symbol)
+    r = Ref{__JL_Ctag_60}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_60}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_60}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5934,7 +6050,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/5495a1e30e8de681b765cec2b10bb5fdd99c7c53/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{__JL_Ctag_60}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 312)
     return getfield(x, f)
 end
@@ -5948,6 +6064,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1,29 +1,37 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)
+    __JL_Ctag_56
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"
+struct __JL_Ctag_56
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_56}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_56, f::Symbol)
+    r = Ref{__JL_Ctag_56}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_56}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/e813521346868ad85885fada20dca527c9d3e056/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_56}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_56, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -91,7 +99,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -243,6 +251,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1311,29 +1327,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)
+    __JL_Ctag_57
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_57
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_57}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_57, f::Symbol)
+    r = Ref{__JL_Ctag_57}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_57}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_57}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_57, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1352,7 +1376,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_57}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1367,6 +1391,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1436,6 +1468,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1735,6 +1775,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2174,14 +2228,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2194,7 +2249,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2207,7 +2263,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2220,7 +2277,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2233,7 +2291,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2246,7 +2305,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2259,7 +2319,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2272,7 +2333,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2285,7 +2347,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2298,7 +2361,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2311,7 +2375,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2324,7 +2389,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2337,7 +2403,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2350,7 +2417,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2363,7 +2431,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2376,7 +2445,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2389,7 +2459,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2402,7 +2473,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2415,7 +2487,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2428,7 +2501,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2441,7 +2515,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2454,7 +2529,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2467,7 +2543,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2480,7 +2557,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2493,7 +2571,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2506,7 +2585,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2517,7 +2597,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5853,17 +5933,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_58
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_58
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_58}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 16)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 32)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 40)
+    f === :do_shutdown && return Ptr{Bool}(x + 48)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_58, f::Symbol)
+    r = Ref{__JL_Ctag_58}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_58}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_58}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5880,7 +5980,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/93d13e00d2f418eb0e6509b57c0bca102b445c92/include/aws/testing/async_stream_tester.h:55:5)"}(x + 184)
+    f === :synced_data && return Ptr{__JL_Ctag_58}(x + 184)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 240)
     return getfield(x, f)
 end
@@ -5894,6 +5994,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1,29 +1,37 @@
-using CEnum
+using CEnum: CEnum, @cenum
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)
+    __JL_Ctag_57
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"
+struct __JL_Ctag_57
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_57}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_57, f::Symbol)
+    r = Ref{__JL_Ctag_57}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_57}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/db709658fff1ff2bd230d232f5788615addbea9c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_57}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_57, private::Bool = false)
+    (:scheduled, :reserved, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -91,7 +99,7 @@ function aws_async_input_stream_release(stream)
 end
 
 """
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
 """
 mutable struct aws_future_bool end
 
@@ -243,6 +251,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_channel_task}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_channel_task, private::Bool = false)
+    (:wrapper_task, :task_fn, :arg, :type_tag, :node, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1311,29 +1327,37 @@ struct aws_socket_endpoint
 end
 
 """
-    union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)
+    __JL_Ctag_58
 
 Documentation not found.
 """
-struct var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)"
+struct __JL_Ctag_58
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)"}, f::Symbol)
+function Base.getproperty(x::Ptr{__JL_Ctag_58}, f::Symbol)
     f === :fd && return Ptr{Cint}(x + 0)
     f === :handle && return Ptr{Ptr{Cvoid}}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)", f::Symbol)
-    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)"}(x)
-    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)"}, r)
+function Base.getproperty(x::__JL_Ctag_58, f::Symbol)
+    r = Ref{__JL_Ctag_58}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_58}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)"}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{__JL_Ctag_58}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::__JL_Ctag_58, private::Bool = false)
+    (:fd, :handle, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void aws_io_set_queue_on_handle_fn ( struct aws_io_handle * handle , void * queue )
@@ -1352,7 +1376,7 @@ struct aws_io_handle
 end
 
 function Base.getproperty(x::Ptr{aws_io_handle}, f::Symbol)
-    f === :data && return Ptr{var"union (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/io/io.h:21:5)"}(x + 0)
+    f === :data && return Ptr{__JL_Ctag_58}(x + 0)
     f === :additional_data && return Ptr{Ptr{Cvoid}}(x + 8)
     f === :set_queue && return Ptr{Ptr{aws_io_set_queue_on_handle_fn}}(x + 16)
     return getfield(x, f)
@@ -1367,6 +1391,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_io_handle}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_io_handle, private::Bool = false)
+    (:data, :additional_data, :set_queue, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 # typedef void ( aws_socket_on_readable_fn ) ( struct aws_socket * socket , int error_code , void * user_data )
@@ -1436,6 +1468,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_socket}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_socket, private::Bool = false)
+    (:vtable, :allocator, :local_endpoint, :remote_endpoint, :options, :io_handle, :event_loop, :handler, :state, :readable_fn, :readable_user_data, :connection_result_fn, :accept_result_fn, :connect_accept_user_data, :impl, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """
@@ -1735,6 +1775,20 @@ size_t aws_event_loop_group_get_loop_count(const struct aws_event_loop_group *el
 """
 function aws_event_loop_group_get_loop_count(el_group)
     ccall((:aws_event_loop_group_get_loop_count, libaws_c_io), Csize_t, (Ptr{aws_event_loop_group},), el_group)
+end
+
+"""
+    aws_event_loop_group_get_type(el_group)
+
+Gets the event loop type used by an event loop group.
+
+### Prototype
+```c
+enum aws_event_loop_type aws_event_loop_group_get_type(const struct aws_event_loop_group *el_group);
+```
+"""
+function aws_event_loop_group_get_type(el_group)
+    ccall((:aws_event_loop_group_get_type, libaws_c_io), aws_event_loop_type, (Ptr{aws_event_loop_group},), el_group)
 end
 
 """
@@ -2174,14 +2228,15 @@ function aws_future_impl_new_pointer_with_release(alloc, result_release)
 end
 
 """
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
 """
 mutable struct aws_future_size end
 
 """
     aws_future_size_new(alloc)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2194,7 +2249,8 @@ end
 """
     aws_future_size_set_result(future, result)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2207,7 +2263,8 @@ end
 """
     aws_future_size_get_result(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2220,7 +2277,8 @@ end
 """
     aws_future_size_acquire(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2233,7 +2291,8 @@ end
 """
     aws_future_size_release(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2246,7 +2305,8 @@ end
 """
     aws_future_size_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2259,7 +2319,8 @@ end
 """
     aws_future_size_is_done(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2272,7 +2333,8 @@ end
 """
     aws_future_size_get_error(future)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2285,7 +2347,8 @@ end
 """
     aws_future_size_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2298,7 +2361,8 @@ end
 """
     aws_future_size_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2311,7 +2375,8 @@ end
 """
     aws_future_size_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2324,7 +2389,8 @@ end
 """
     aws_future_size_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2337,7 +2403,8 @@ end
 """
     aws_future_size_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<size\\_t> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_size, size_t, AWS_IO_API);
@@ -2350,7 +2417,8 @@ end
 """
     aws_future_bool_new(alloc)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2363,7 +2431,8 @@ end
 """
     aws_future_bool_set_result(future, result)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2376,7 +2445,8 @@ end
 """
     aws_future_bool_get_result(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2389,7 +2459,8 @@ end
 """
     aws_future_bool_acquire(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2402,7 +2473,8 @@ end
 """
     aws_future_bool_release(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2415,7 +2487,8 @@ end
 """
     aws_future_bool_set_error(future, error_code)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2428,7 +2501,8 @@ end
 """
     aws_future_bool_is_done(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2441,7 +2515,8 @@ end
 """
     aws_future_bool_get_error(future)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2454,7 +2529,8 @@ end
 """
     aws_future_bool_register_callback(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2467,7 +2543,8 @@ end
 """
     aws_future_bool_register_callback_if_not_done(future, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2480,7 +2557,8 @@ end
 """
     aws_future_bool_register_event_loop_callback(future, event_loop, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2493,7 +2571,8 @@ end
 """
     aws_future_bool_register_channel_callback(future, channel, on_done, user_data)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2506,7 +2585,8 @@ end
 """
     aws_future_bool_wait(future, timeout_ns)
 
-Documentation not found.
+aws\\_future<bool> See top of future.h for docs.
+
 ### Prototype
 ```c
 AWS_FUTURE_T_BY_VALUE_DECLARATION(aws_future_bool, bool, AWS_IO_API);
@@ -2517,7 +2597,7 @@ function aws_future_bool_wait(future, timeout_ns)
 end
 
 """
-Documentation not found.
+aws\\_future<void> See top of future.h for docs.
 """
 mutable struct aws_future_void end
 
@@ -5868,17 +5948,37 @@ struct aws_async_input_stream_tester_options
 end
 
 """
-    var"struct (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/testing/async_stream_tester.h:55:5)"
+    __JL_Ctag_59
 
 Documentation not found.
 """
-struct var"struct (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/testing/async_stream_tester.h:55:5)"
+struct __JL_Ctag_59
     lock::aws_mutex
     cvar::aws_condition_variable
     read_dest::Ptr{aws_byte_buf}
     read_future::Ptr{aws_future_bool}
     do_shutdown::Bool
 end
+function Base.getproperty(x::Ptr{__JL_Ctag_59}, f::Symbol)
+    f === :lock && return Ptr{aws_mutex}(x + 0)
+    f === :cvar && return Ptr{aws_condition_variable}(x + 16)
+    f === :read_dest && return Ptr{Ptr{aws_byte_buf}}(x + 32)
+    f === :read_future && return Ptr{Ptr{aws_future_bool}}(x + 40)
+    f === :do_shutdown && return Ptr{Bool}(x + 48)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::__JL_Ctag_59, f::Symbol)
+    r = Ref{__JL_Ctag_59}(x)
+    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_59}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{__JL_Ctag_59}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
 
 """
     aws_async_input_stream_tester
@@ -5895,7 +5995,7 @@ function Base.getproperty(x::Ptr{aws_async_input_stream_tester}, f::Symbol)
     f === :options && return Ptr{aws_async_input_stream_tester_options}(x + 56)
     f === :source_stream && return Ptr{Ptr{aws_input_stream}}(x + 152)
     f === :thread && return Ptr{aws_thread}(x + 160)
-    f === :synced_data && return Ptr{var"struct (unnamed at /home/runner/.julia/artifacts/50c547aea826069f8b4c6bd425686207d26c2fb0/include/aws/testing/async_stream_tester.h:55:5)"}(x + 192)
+    f === :synced_data && return Ptr{__JL_Ctag_59}(x + 192)
     f === :num_outstanding_reads && return Ptr{aws_atomic_var}(x + 248)
     return getfield(x, f)
 end
@@ -5909,6 +6009,14 @@ end
 
 function Base.setproperty!(x::Ptr{aws_async_input_stream_tester}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::aws_async_input_stream_tester, private::Bool = false)
+    (:base, :alloc, :options, :source_stream, :thread, :synced_data, :num_outstanding_reads, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 """


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_io_jll** to version **0.23.3**
- Updated **JuliaServices/LibAwsIO.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings