### PR TITLE
Update aws_c_io_jll to version 0.25.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsIO"
 uuid = "a5388770-19df-4151-b103-3d71de896ddf"
-version = "1.3.4"
+version = "1.3.5"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -13,7 +13,7 @@ Aqua = "0.7,0.8"
 CEnum = "0.5"
 LibAwsCal = "1.1.5"
 LibAwsCommon = "1.2.4"
-aws_c_io_jll = "=0.24.2"
+aws_c_io_jll = "=0.25.0"
 julia = "1.6"
 Test = "1.9"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -10,4 +10,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3,0.19"
 JLLPrefixes = "0.3,0.4"
-aws_c_io_jll = "=0.24.2"
+aws_c_io_jll = "=0.25.0"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1554,9 +1554,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1554,9 +1554,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1624,9 +1624,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1554,9 +1554,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1624,9 +1624,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1554,9 +1554,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1624,9 +1624,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1554,9 +1554,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1554,9 +1554,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1554,9 +1554,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1624,9 +1624,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1554,9 +1554,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1554,9 +1554,9 @@ end
 """
     aws_event_loop_type
 
-Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default. The default is determined via the `aws\\_event\\_loop\\_get\\_default\\_type()` function based on which event loop types have been defined.
+Event Loop Type. If set to `AWS_EVENT_LOOP_PLATFORM_DEFAULT`, the event loop will automatically use the platform’s default.
 
-Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE Apple | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
+Default Event Loop Type Linux | AWS\\_EVENT\\_LOOP\\_EPOLL Windows | AWS\\_EVENT\\_LOOP\\_IOCP BSD Variants| AWS\\_EVENT\\_LOOP\\_KQUEUE macOS | AWS\\_EVENT\\_LOOP\\_KQUEUE iOS | AWS\\_EVENT\\_LOOP\\_DISPATCH\\_QUEUE
 """
 @cenum aws_event_loop_type::UInt32 begin
     AWS_EVENT_LOOP_PLATFORM_DEFAULT = 0


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_io_jll** to version **0.25.0**
- Updated **JuliaServices/LibAwsIO.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings