### PR TITLE
Update aws_c_io_jll to version 0.26.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsIO"
 uuid = "a5388770-19df-4151-b103-3d71de896ddf"
-version = "1.3.4"
+version = "1.3.5"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -13,7 +13,7 @@ Aqua = "0.7,0.8"
 CEnum = "0.5"
 LibAwsCal = "1.1.5"
 LibAwsCommon = "1.2.4"
-aws_c_io_jll = "=0.25.0"
+aws_c_io_jll = "=0.26.0"
 julia = "1.6"
 Test = "1.9"
 

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -10,4 +10,4 @@ aws_c_io_jll = "13c41daa-f319-5298-b5eb-5754e0170d52"
 [compat]
 Clang = "0.18.3,0.19"
 JLLPrefixes = "0.3,0.4"
-aws_c_io_jll = "=0.25.0"
+aws_c_io_jll = "=0.26.0"


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_io_jll** to version **0.26.0**
- Updated **JuliaServices/LibAwsIO.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings